### PR TITLE
🚑 Fix crashing when unexpected files/dirs are present in "wbfs" or "g…

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -138,9 +138,13 @@ impl App {
         }
 
         for entry in std::fs::read_dir(&dir)? {
-            let path = entry?.path();
-            if path.is_dir() {
-                games.push(Game::from_path(path)?);
+            if let Ok(entry) = entry {
+                let path = entry.path();
+                if path.is_dir() {
+                    if let Ok(game) = Game::from_path(path) {
+                        games.push(game);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
…ames"