### PR TITLE
Run CI on every commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,18 +2,10 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v*.*.*"
+  pull_request:
 
 permissions:
   contents: write
-
-# ==================================================================================
-#  Concurrency: Ensures only one release workflow runs at a time for a given tag.
-# ==================================================================================
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   # ==================================================================================
@@ -177,6 +169,7 @@ jobs:
   # ==================================================================================
   release:
     name: Create GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [ build-linux, build-windows, build-macos ]
     steps:


### PR DESCRIPTION
This makes CI run on every commit and pull request, but guards the release step behind `if: startsWith(github.ref, 'refs/tags/v')`.

Concurrency removed because you may have `push` and `pull_requests` events running on the same ref. There can't be two `push` events for the same tag, so it doesn't really help anything.