### PR TITLE
GameTDB `wiitdb.xml` support & game cover caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +365,21 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -972,6 +996,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -2367,6 +2403,15 @@ dependencies = [
  "bitflags 2.9.3",
  "libc",
  "redox_syscall 0.5.17",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3617,6 +3662,7 @@ version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -3647,6 +3693,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
@@ -4322,6 +4369,7 @@ dependencies = [
  "wgpu",
  "winres",
  "zerocopy",
+ "zip",
  "zstd",
 ]
 
@@ -5916,6 +5964,25 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zip"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835eb39822904d39cb19465de1159e05d371973f0c6df3a365ad50565ddc8b9"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,6 @@ checksum = "8ae8f23013328beb6be7ab29c75807142e8e1c7951643780a813e54cceaa9929"
 dependencies = [
  "ahash",
  "egui",
- "ehttp",
  "enum-map",
  "image",
  "log",
@@ -1210,20 +1209,6 @@ checksum = "8031fefc60b0170b304a8b12df0bd3531359410c3e709a2ccf33f7f58f856428"
 dependencies = [
  "egui",
  "parking_lot",
-]
-
-[[package]]
-name = "ehttp"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a81c221a1e4dad06cb9c9deb19aea1193a5eea084e8cd42d869068132bf876"
-dependencies = [
- "document-features",
- "js-sys",
- "ureq 2.12.1",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -1944,7 +1929,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3669,7 +3654,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4333,7 +4318,7 @@ dependencies = [
  "serde",
  "size",
  "tempfile",
- "ureq 3.1.0",
+ "ureq",
  "wgpu",
  "winres",
  "zerocopy",
@@ -4593,22 +4578,6 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "ureq"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00432f493971db5d8e47a65aeb3b02f8226b9b11f1450ff86bb772776ebadd70"
@@ -4622,7 +4591,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
- "webpki-roots 1.0.2",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4933,15 +4902,6 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "url",
  "web-sys",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +550,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,7 +902,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1427,12 +1451,21 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1445,6 +1478,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1483,6 +1522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1522,6 +1562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
 name = "futures-task"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1582,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1560,8 +1607,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1571,10 +1620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gl_generator"
@@ -1717,6 +1774,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1871,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1906,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d15931895091dea5c47afa5b3c9a01ba634b311919fd4d41388fa0e3d76af"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.0",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1967,6 +2147,33 @@ checksum = "c774c86bce20ea04abe1c37cf0051c5690079a3a28ef5fdac2a5a0412b3d7d74"
 dependencies = [
  "block-padding",
  "hybrid-array",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.3",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2227,6 +2434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,7 +2491,7 @@ dependencies = [
  "bitflags 2.9.3",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
@@ -2347,6 +2560,23 @@ dependencies = [
  "strum",
  "thiserror 2.0.16",
  "unicode-ident",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2796,6 +3026,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,6 +3055,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.3",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3165,6 +3448,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.16",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,6 +3627,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
 name = "rfd"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3722,12 @@ dependencies = [
  "serde_derive",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -3407,6 +3797,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3428,6 +3819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,6 +3840,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5891758e27920d31e8a406b37a31b474290ef079839261ceadab459fa39c7389"
 dependencies = [
  "const_format",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3468,6 +3874,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.3",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3497,6 +3926,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3505,6 +3946,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3627,6 +4080,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3693,6 +4166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,6 +4183,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.3",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3823,11 +4326,13 @@ dependencies = [
  "open",
  "phf 0.13.1",
  "quick-xml 0.37.5",
+ "reqwest",
  "rfd",
  "sanitize-filename-reader-friendly",
  "semver",
  "serde",
  "size",
+ "tempfile",
  "ureq 3.1.0",
  "wgpu",
  "winres",
@@ -3843,6 +4348,71 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "slab",
+ "socket2 0.6.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3870,6 +4440,51 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.3",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3901,6 +4516,12 @@ checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -4053,6 +4674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,6 +4693,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -4628,6 +5264,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ filetime = "0.2"
 num_cpus = "1.17"
 sanitize-filename-reader-friendly = "2.3"
 serde = { version = "1.0", features = ["derive"] }
+quick-xml = { version = "0.37", features = ["serialize"] }
 
 [build-dependencies]
 quick-xml = { version = "0.37", features = ["serialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ num_cpus = "1.17"
 sanitize-filename-reader-friendly = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
-reqwest = { version = "0.12", features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "deflate", "zstd"] }
+zip = { version = "4.5", default-features = false, features = ["deflate-flate2-zlib-rs"] }
 
 [build-dependencies]
 quick-xml = { version = "0.37", features = ["serialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ num_cpus = "1.17"
 sanitize-filename-reader-friendly = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
+reqwest = { version = "0.12", features = ["blocking", "rustls-tls"] }
 
 [build-dependencies]
 quick-xml = { version = "0.37", features = ["serialize"] }
@@ -69,6 +70,9 @@ wgpu = { version = "25", default-features = false, features = ["dx12"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
+
+[dev-dependencies]
+tempfile = "3.13"
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ OriginalFilename = "TinyWiiBackupManager.exe"
 LegalCopyright = "Copyright © 2025 Manuel Quarneti. Licensed under GPL-2.0-only."
 
 [dependencies]
-egui_extras = { version = "0.32", features = ["image", "http"] }
+egui_extras = { version = "0.32", features = ["image", "file"] }
 egui-notify = "0.20"
 egui_inbox = "0.9"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde = { version = "1.0", features = ["derive"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
 reqwest = { version = "0.12", features = ["blocking", "rustls-tls", "deflate", "zstd"] }
 zip = { version = "4.5", default-features = false, features = ["deflate-flate2-zlib-rs"] }
+tempfile = "3.13"
 
 [build-dependencies]
 quick-xml = { version = "0.37", features = ["serialize"] }
@@ -71,9 +72,6 @@ wgpu = { version = "25", default-features = false, features = ["dx12"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
-
-[dev-dependencies]
-tempfile = "3.13"
 
 [profile.release]
 opt-level = 3

--- a/src/app.rs
+++ b/src/app.rs
@@ -294,10 +294,25 @@ impl App {
             self.bottom_right_toasts
                 .add(error_toast("Failed to refresh games", &e));
         }
+
+        // Apply calculated hashes to the newly converted games
+        for (game_path, calculated_hashes) in res.hashes {
+            if let Some(game) = self.games.iter_mut().find(|g| g.path == game_path) {
+                game.set_verification_status(calculated_hashes.into_verification_status());
+                break;
+            }
+        }
     }
 
     /// Handle verify job result
     pub fn handle_verify_result(&mut self, status: JobStatus, res: VerifyResult) {
+        // Apply verification statuses to the games
+        for (game_path, verification_status) in res.results {
+            if let Some(game) = self.games.iter_mut().find(|g| g.path == game_path) {
+                game.set_verification_status(verification_status);
+            }
+        }
+
         if res.failed > 0 {
             self.bottom_right_toasts.warning(status.status);
         } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -210,7 +210,7 @@ impl App {
         });
     }
 
-    /// Converts ISO files to WBFS using the job system
+    /// Converts ISO files to WBFS
     fn spawn_conversion_worker(&mut self, paths: Vec<PathBuf>) {
         if let Some(base_dir) = &self.base_dir {
             self.jobs.push_once(Job::Convert, || {
@@ -232,7 +232,7 @@ impl App {
         self.open_info_windows.insert(index);
     }
 
-    /// Spawn a verification task for multiple games using the job system
+    /// Spawn a verification task for multiple games
     pub fn spawn_verification(&mut self, games: Vec<Game>) {
         self.jobs.push_once(Job::Verify, || {
             start_verify(egui_waker(&self.ctx), VerifyConfig { games })

--- a/src/app.rs
+++ b/src/app.rs
@@ -97,6 +97,8 @@ pub struct App {
     pub cover_manager: Option<CoverManager>,
     /// Job queue for background tasks
     pub jobs: JobQueue,
+    /// Whether the jobs window is open
+    pub show_jobs_window: bool,
 }
 
 impl App {

--- a/src/app.rs
+++ b/src/app.rs
@@ -115,7 +115,7 @@ impl App {
         // Load base dir from storage
         if let Some(storage) = cc.storage {
             app.base_dir = eframe::get_value(storage, "base_dir");
-            
+
             // Initialize cover manager if we have a base directory
             if let Some(ref base_dir) = app.base_dir {
                 app.cover_manager = Some(CoverManager::new(base_dir.path().to_path_buf()));

--- a/src/app.rs
+++ b/src/app.rs
@@ -268,21 +268,18 @@ impl App {
                         ));
                     }
 
-                    let mut success = false;
-                    let (game_path, result) = match convert::convert_game(
+                    let (game_path, result, success) = match convert::convert_game(
                         path,
                         &base_dir,
                         sender.clone(),
                         Arc::clone(&cancelled),
                     ) {
-                        Ok((game_dir, calculated_hashes)) => {
-                            success = true;
-                            (
-                                game_dir,
-                                OperationResult::ConversionComplete(calculated_hashes),
-                            )
-                        }
-                        Err(e) => (base_dir.clone(), OperationResult::Error(e)),
+                        Ok((game_dir, calculated_hashes)) => (
+                            game_dir,
+                            OperationResult::ConversionComplete(calculated_hashes),
+                            true,
+                        ),
+                        Err(e) => (base_dir.clone(), OperationResult::Error(e), false),
                     };
 
                     // Send completion message for this file

--- a/src/base_dir.rs
+++ b/src/base_dir.rs
@@ -67,8 +67,8 @@ impl BaseDir {
     /// Scans the "wbfs" and "games" directories and get the list of games and the size of the base directory
     pub fn get_games(&self) -> Result<(Vec<Game>, u64)> {
         let mut games = Vec::new();
-        scan_dir(self.wii_dir(), &mut games, ConsoleType::Wii)?;
-        scan_dir(self.gc_dir(), &mut games, ConsoleType::GameCube)?;
+        scan_dir(self.wii_dir(), &mut games, ConsoleType::Wii, &self.0)?;
+        scan_dir(self.gc_dir(), &mut games, ConsoleType::GameCube, &self.0)?;
 
         // Sort the combined vector
         games.sort_by(|a, b| a.display_title.cmp(&b.display_title));
@@ -102,7 +102,12 @@ impl fmt::Display for BaseDir {
 }
 
 /// Scans a directory for games
-fn scan_dir(dir: impl AsRef<Path>, games: &mut Vec<Game>, console_type: ConsoleType) -> Result<()> {
+fn scan_dir(
+    dir: impl AsRef<Path>,
+    games: &mut Vec<Game>,
+    console_type: ConsoleType,
+    base_dir: &Path,
+) -> Result<()> {
     let dir = dir.as_ref();
 
     if !dir.is_dir() {
@@ -113,7 +118,7 @@ fn scan_dir(dir: impl AsRef<Path>, games: &mut Vec<Game>, console_type: ConsoleT
         .filter_map(Result::ok)
         .map(|entry| entry.path())
         .filter(|path| path.is_dir())
-        .filter_map(|path| Game::from_path(path, console_type).ok())
+        .filter_map(|path| Game::from_path(path, console_type, Some(base_dir)).ok())
         .for_each(|game| {
             games.push(game);
         });

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -8,27 +8,17 @@ impl eframe::App for App {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Process job results
         self.jobs.collect_results();
-
-        // Take results out to avoid borrow checker issues
         let results = std::mem::take(&mut self.jobs.results);
-        for result in results {
+        for (result, status) in results {
             match result {
-                JobResult::DownloadCovers(res) => {
-                    self.handle_download_covers_result(&res, ctx);
-                }
+                JobResult::DownloadCovers(res) => self.handle_download_covers_result(status, *res),
                 JobResult::DownloadDatabase(res) => {
-                    self.handle_download_database_result(&res);
+                    self.handle_download_database_result(status, *res)
                 }
-                JobResult::Convert(res) => {
-                    self.handle_convert_result(&res);
-                }
-                JobResult::Verify(res) => {
-                    self.handle_verify_result(&res);
-                }
-                _ => {
-                    // Put back unhandled results
-                    self.jobs.results.push(result);
-                }
+                JobResult::Convert(res) => self.handle_convert_result(status, *res),
+                JobResult::Verify(res) => self.handle_verify_result(status, *res),
+                // Put back unhandled results
+                _ => self.jobs.results.push((result, status)),
             }
         }
 

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -58,6 +58,9 @@ impl eframe::App for App {
             })
         });
 
+        // Render jobs window if open
+        components::jobs::jobs_window(ctx, &mut self.show_jobs_window, &mut self.jobs);
+
         self.top_left_toasts.show(ctx);
         self.bottom_left_toasts.show(ctx);
         self.bottom_right_toasts.show(ctx);

--- a/src/components/bottom_panel.rs
+++ b/src/components/bottom_panel.rs
@@ -28,10 +28,10 @@ pub fn ui_bottom_panel(ctx: &egui::Context, app: &mut App) {
 
                 // Show jobs menu UI
                 ui.separator();
-                ui.label("Jobs:");
                 if crate::components::jobs::jobs_menu_ui(ui, &mut app.jobs) {
                     app.show_jobs_window = true;
                 }
+                ui.label("Jobs:");
             });
         });
     });

--- a/src/components/bottom_panel.rs
+++ b/src/components/bottom_panel.rs
@@ -25,6 +25,34 @@ pub fn ui_bottom_panel(ctx: &egui::Context, app: &mut App) {
 
                 ui.separator();
                 ui_console_filter(ui, &mut app.console_filter);
+
+                // Show active jobs count
+                let active_count = app.jobs.active_count();
+                if active_count > 0 {
+                    ui.separator();
+
+                    // Show job count with progress
+                    let job_text = format!(
+                        "⚙ {} job{}",
+                        active_count,
+                        if active_count == 1 { "" } else { "s" }
+                    );
+
+                    // Show first job's progress as tooltip
+                    if let Some(job) = app.jobs.jobs.first() {
+                        if let Ok(status) = job.context.status.read() {
+                            let mut tooltip = status.status.clone();
+                            if let Some([current, total]) = status.progress_items {
+                                tooltip.push_str(&format!(" ({}/{})", current, total));
+                            }
+                            ui.label(job_text).on_hover_text(tooltip);
+                        } else {
+                            ui.label(job_text);
+                        }
+                    } else {
+                        ui.label(job_text);
+                    }
+                }
             });
         });
     });

--- a/src/components/bottom_panel.rs
+++ b/src/components/bottom_panel.rs
@@ -26,32 +26,11 @@ pub fn ui_bottom_panel(ctx: &egui::Context, app: &mut App) {
                 ui.separator();
                 ui_console_filter(ui, &mut app.console_filter);
 
-                // Show active jobs count
-                let active_count = app.jobs.active_count();
-                if active_count > 0 {
-                    ui.separator();
-
-                    // Show job count with progress
-                    let job_text = format!(
-                        "⚙ {} job{}",
-                        active_count,
-                        if active_count == 1 { "" } else { "s" }
-                    );
-
-                    // Show first job's progress as tooltip
-                    if let Some(job) = app.jobs.jobs.first() {
-                        if let Ok(status) = job.context.status.read() {
-                            let mut tooltip = status.status.clone();
-                            if let Some([current, total]) = status.progress_items {
-                                tooltip.push_str(&format!(" ({}/{})", current, total));
-                            }
-                            ui.label(job_text).on_hover_text(tooltip);
-                        } else {
-                            ui.label(job_text);
-                        }
-                    } else {
-                        ui.label(job_text);
-                    }
+                // Show jobs menu UI
+                ui.separator();
+                ui.label("Jobs:");
+                if crate::components::jobs::jobs_menu_ui(ui, &mut app.jobs) {
+                    app.show_jobs_window = true;
                 }
             });
         });

--- a/src/components/game_grid.rs
+++ b/src/components/game_grid.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Manuel Quarneti <mq1@ik.me>
 // SPDX-License-Identifier: GPL-2.0-only
 
+use crate::cover_manager::{CoverManager, CoverType};
 use crate::messages::BackgroundMessage;
 use crate::{
     app::App,
@@ -17,6 +18,7 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
 
     let mut to_remove = None;
     let mut to_open_info = None;
+    let mut covers_to_download = Vec::new();
 
     egui::ScrollArea::vertical().show(ui, |ui| {
         // expand horizontally
@@ -34,12 +36,15 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
 
                 for (original_index, game) in app.games.iter().enumerate() {
                     if filter.shows_game(game) {
-                        let (should_remove, should_open_info) = ui_game_card(ui, game);
+                        let (should_remove, should_open_info, should_download_cover) = ui_game_card(ui, game, &app.cover_manager);
                         if should_remove {
                             to_remove = Some((*game).clone());
                         }
                         if should_open_info {
                             to_open_info = Some(original_index);
+                        }
+                        if should_download_cover {
+                            covers_to_download.push(game.id.clone());
                         }
 
                         column_index += 1;
@@ -50,6 +55,13 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
                 }
             });
     });
+
+    // Handle cover downloads after the UI loop
+    if let Some(cover_manager) = &app.cover_manager {
+        for game_id in covers_to_download {
+            cover_manager.queue_download(game_id, CoverType::Cover3D, sender.clone());
+        }
+    }
 
     if let Some(game) = to_remove
         && let Err(e) = game.remove()
@@ -62,9 +74,10 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
     }
 }
 
-fn ui_game_card(ui: &mut egui::Ui, game: &Game) -> (bool, bool) {
+fn ui_game_card(ui: &mut egui::Ui, game: &Game, cover_manager: &Option<CoverManager>) -> (bool, bool, bool) {
     let mut remove_clicked = false;
     let mut info_clicked = false;
+    let mut should_download_cover = false;
 
     let card = egui::Frame::group(ui.style()).corner_radius(5.0);
     card.show(ui, |ui| {
@@ -105,11 +118,43 @@ fn ui_game_card(ui: &mut egui::Ui, game: &Game) -> (bool, bool) {
 
             // Centered content
             ui.with_layout(egui::Layout::top_down(egui::Align::Center), |ui| {
-                let image = Image::new(&game.image_url)
-                    .max_height(128.0)
-                    .maintain_aspect_ratio(true)
-                    .show_loading_spinner(true);
-                ui.add(image);
+                // Handle cover art
+                if let Some(cover_manager) = cover_manager {
+                    let cover_path = cover_manager.get_cover_path(&game.id, CoverType::Cover3D);
+                    
+                    if cover_path.exists() {
+                        // Show existing local cover
+                        let image = Image::new(format!("file://{}", cover_path.display()))
+                            .max_height(128.0)
+                            .maintain_aspect_ratio(true);
+                        ui.add(image);
+                    } else if cover_manager.is_downloading(&game.id, CoverType::Cover3D) {
+                        // Show placeholder while downloading
+                        ui.allocate_ui(egui::vec2(128.0, 128.0), |ui| {
+                            ui.centered_and_justified(|ui| {
+                                ui.spinner();
+                                ui.label("Downloading cover...");
+                            });
+                        });
+                    } else {
+                        // Show placeholder and mark for download
+                        ui.allocate_ui(egui::vec2(128.0, 128.0), |ui| {
+                            ui.centered_and_justified(|ui| {
+                                ui.label("📦");
+                            });
+                        });
+                        
+                        // Mark for download
+                        should_download_cover = true;
+                    }
+                } else {
+                    // No cover manager - show placeholder
+                    ui.allocate_ui(egui::vec2(128.0, 128.0), |ui| {
+                        ui.centered_and_justified(|ui| {
+                            ui.label("🎮");
+                        });
+                    });
+                }
 
                 ui.add_space(5.);
 
@@ -133,5 +178,5 @@ fn ui_game_card(ui: &mut egui::Ui, game: &Game) -> (bool, bool) {
         });
     });
 
-    (remove_clicked, info_clicked)
+    (remove_clicked, info_clicked, should_download_cover)
 }

--- a/src/components/game_grid.rs
+++ b/src/components/game_grid.rs
@@ -60,7 +60,7 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
     // Handle cover downloads after the UI loop
     if let Some(cover_manager) = &app.cover_manager {
         for game_id in covers_to_download {
-            cover_manager.queue_download(game_id, CoverType::Cover3D, sender.clone());
+            cover_manager.queue_download(game_id, CoverType::Cover3D);
         }
     }
 

--- a/src/components/game_grid.rs
+++ b/src/components/game_grid.rs
@@ -53,8 +53,6 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
             });
     });
 
-    // Cover downloads are now handled via the GameTDB menu
-
     if let Some(game) = to_remove
         && let Err(e) = game.remove()
     {
@@ -116,7 +114,6 @@ fn ui_game_card(
                 // Handle cover art
                 if let Some(cover_manager) = cover_manager {
                     let cover_path = cover_manager.get_cover_path(&game.id, CoverType::Cover3D);
-
                     if cover_path.exists() {
                         // Show existing local cover
                         let image = Image::new(format!("file://{}", cover_path.display()))
@@ -124,7 +121,7 @@ fn ui_game_card(
                             .maintain_aspect_ratio(true);
                         ui.add(image);
                     } else {
-                        // Show placeholder - covers can be downloaded via the GameTDB menu
+                        // Show placeholder
                         ui.allocate_ui(egui::vec2(128.0, 128.0), |ui| {
                             ui.centered_and_justified(|ui| {
                                 ui.label("📦");

--- a/src/components/game_grid.rs
+++ b/src/components/game_grid.rs
@@ -36,7 +36,8 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
 
                 for (original_index, game) in app.games.iter().enumerate() {
                     if filter.shows_game(game) {
-                        let (should_remove, should_open_info, should_download_cover) = ui_game_card(ui, game, &app.cover_manager);
+                        let (should_remove, should_open_info, should_download_cover) =
+                            ui_game_card(ui, game, &app.cover_manager);
                         if should_remove {
                             to_remove = Some((*game).clone());
                         }
@@ -74,7 +75,11 @@ pub fn ui_game_grid(ui: &mut egui::Ui, app: &mut App) {
     }
 }
 
-fn ui_game_card(ui: &mut egui::Ui, game: &Game, cover_manager: &Option<CoverManager>) -> (bool, bool, bool) {
+fn ui_game_card(
+    ui: &mut egui::Ui,
+    game: &Game,
+    cover_manager: &Option<CoverManager>,
+) -> (bool, bool, bool) {
     let mut remove_clicked = false;
     let mut info_clicked = false;
     let mut should_download_cover = false;
@@ -121,7 +126,7 @@ fn ui_game_card(ui: &mut egui::Ui, game: &Game, cover_manager: &Option<CoverMana
                 // Handle cover art
                 if let Some(cover_manager) = cover_manager {
                     let cover_path = cover_manager.get_cover_path(&game.id, CoverType::Cover3D);
-                    
+
                     if cover_path.exists() {
                         // Show existing local cover
                         let image = Image::new(format!("file://{}", cover_path.display()))
@@ -143,7 +148,7 @@ fn ui_game_card(ui: &mut egui::Ui, game: &Game, cover_manager: &Option<CoverMana
                                 ui.label("📦");
                             });
                         });
-                        
+
                         // Mark for download
                         should_download_cover = true;
                     }

--- a/src/components/jobs.rs
+++ b/src/components/jobs.rs
@@ -3,14 +3,9 @@ use eframe::egui::{self, ProgressBar, RichText, Widget};
 use std::cmp::Ordering;
 
 pub fn jobs_ui(ui: &mut egui::Ui, jobs: &mut JobQueue) {
-    ui.horizontal(|ui| {
-        if ui.button("Clear finished").clicked() {
-            jobs.clear_finished();
-        }
-        if ui.button("Clear errors").clicked() {
-            jobs.clear_errored();
-        }
-    });
+    if ui.button("Clear").clicked() {
+        jobs.clear_errored();
+    }
 
     let mut remove_job: Option<usize> = None;
     let mut any_jobs = false;

--- a/src/components/jobs.rs
+++ b/src/components/jobs.rs
@@ -1,0 +1,153 @@
+use crate::jobs::{JobQueue, JobStatus};
+use eframe::egui::{self, ProgressBar, RichText, Widget};
+use std::cmp::Ordering;
+
+pub fn jobs_ui(ui: &mut egui::Ui, jobs: &mut JobQueue) {
+    ui.horizontal(|ui| {
+        if ui.button("Clear finished").clicked() {
+            jobs.clear_finished();
+        }
+        if ui.button("Clear errors").clicked() {
+            jobs.clear_errored();
+        }
+    });
+
+    let mut remove_job: Option<usize> = None;
+    let mut any_jobs = false;
+    for job in jobs.iter_mut() {
+        let Ok(status) = job.context.status.read() else {
+            continue;
+        };
+        any_jobs = true;
+        ui.separator();
+        ui.horizontal(|ui| {
+            ui.label(&status.title);
+            if ui.small_button("✖").clicked() {
+                if job.handle.is_some() {
+                    if let Err(e) = job.cancel.send(()) {
+                        log::error!("Failed to cancel job: {e:?}");
+                    }
+                } else {
+                    remove_job = Some(job.id);
+                }
+            }
+        });
+        let mut bar = ProgressBar::new(status.progress_percent);
+        if let Some(items) = &status.progress_items {
+            bar = bar.text(format!("{} / {}", items[0], items[1]));
+        }
+        bar.ui(ui);
+        const STATUS_LENGTH: usize = 60;
+        if let Some(err) = &status.error {
+            let err_string = format!("{err:#}");
+            let delete_color = ui.visuals().error_fg_color;
+            ui.colored_label(
+                delete_color,
+                if err_string.len() > STATUS_LENGTH - 10 {
+                    format!("Error: {}…", &err_string[0..STATUS_LENGTH - 10])
+                } else {
+                    format!("Error: {:width$}", err_string, width = STATUS_LENGTH - 7)
+                },
+            )
+            .on_hover_text_at_pointer(RichText::new(&err_string).color(delete_color))
+            .context_menu(|ui| {
+                if ui.button("Copy full message").clicked() {
+                    ui.ctx().copy_text(err_string);
+                }
+            });
+        } else {
+            ui.label(if status.status.len() > STATUS_LENGTH - 3 {
+                format!("{}…", &status.status[0..STATUS_LENGTH - 3])
+            } else {
+                format!("{:width$}", &status.status, width = STATUS_LENGTH)
+            })
+            .on_hover_text_at_pointer(&status.status)
+            .context_menu(|ui| {
+                if ui.button("Copy full message").clicked() {
+                    ui.ctx().copy_text(status.status.clone());
+                }
+            });
+        }
+    }
+    if !any_jobs {
+        ui.label("No jobs");
+    }
+
+    if let Some(idx) = remove_job {
+        jobs.remove(idx);
+    }
+}
+
+struct JobStatusDisplay {
+    title: String,
+    progress_items: Option<[u32; 2]>,
+    error: bool,
+}
+
+impl From<&JobStatus> for JobStatusDisplay {
+    fn from(status: &JobStatus) -> Self {
+        Self {
+            title: status.title.clone(),
+            progress_items: status.progress_items,
+            error: status.error.is_some(),
+        }
+    }
+}
+
+pub fn jobs_menu_ui(ui: &mut egui::Ui, jobs: &mut JobQueue) -> bool {
+    let mut statuses = Vec::new();
+    for job in jobs.iter_mut() {
+        let Ok(status) = job.context.status.read() else {
+            continue;
+        };
+        statuses.push(JobStatusDisplay::from(&*status));
+    }
+    let running_jobs = statuses.iter().filter(|s| !s.error).count();
+    let error_jobs = statuses.iter().filter(|s| s.error).count();
+
+    let mut clicked = false;
+    let spinner = egui::Spinner::new().size(ui.text_style_height(&egui::TextStyle::Body) * 0.9);
+    match running_jobs.cmp(&1) {
+        Ordering::Equal => {
+            spinner.ui(ui);
+            let running_job = statuses.iter().find(|s| !s.error).unwrap();
+            let text = if let Some(items) = running_job.progress_items {
+                format!("{} ({}/{})", running_job.title, items[0], items[1])
+            } else {
+                running_job.title.clone()
+            };
+            clicked |= ui.link(RichText::new(text)).clicked();
+        }
+        Ordering::Greater => {
+            spinner.ui(ui);
+            clicked |= ui.link(format!("{running_jobs} running")).clicked();
+        }
+        _ => (),
+    }
+    match error_jobs.cmp(&1) {
+        Ordering::Equal => {
+            let error_job = statuses.iter().find(|s| s.error).unwrap();
+            let error_color = ui.visuals().error_fg_color;
+            clicked |= ui
+                .link(RichText::new(format!("{} error", error_job.title)).color(error_color))
+                .clicked();
+        }
+        Ordering::Greater => {
+            let error_color = ui.visuals().error_fg_color;
+            clicked |= ui
+                .link(RichText::new(format!("{error_jobs} errors")).color(error_color))
+                .clicked();
+        }
+        _ => (),
+    }
+    if running_jobs == 0 && error_jobs == 0 {
+        clicked |= ui.link("None").clicked();
+    }
+    clicked
+}
+
+pub fn jobs_window(ctx: &egui::Context, show: &mut bool, jobs: &mut JobQueue) {
+    egui::Window::new("Jobs").open(show).show(ctx, |ui| {
+        jobs_ui(ui, jobs);
+    });
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -7,5 +7,6 @@ pub mod console_filter;
 pub mod fake_link;
 pub mod game_grid;
 pub mod game_info;
+pub mod jobs;
 pub mod operation_modal;
 pub mod top_panel;

--- a/src/components/operation_modal.rs
+++ b/src/components/operation_modal.rs
@@ -1,88 +1,102 @@
-use crate::app::{App, OperationState, OperationType};
-use crate::messages::BackgroundMessage;
+use crate::app::App;
+use crate::jobs::Job;
 use eframe::egui;
 use size::Size;
 
-pub fn ui_operation_modal(ctx: &egui::Context, app: &App) {
-    if let OperationState::InProgress {
-        operation,
-        total_items,
-        items_completed,
-        current_item,
-        current_progress,
-        ..
-    } = &app.operation_state
-    {
-        let modal_id = match operation {
-            OperationType::Converting => "conversion_modal",
-            OperationType::Verifying => "verification_modal",
+pub fn ui_operation_modal(ctx: &egui::Context, app: &mut App) {
+    // Check if conversion or verification job is running
+    let convert_job = app.jobs.get_job_by_kind(Job::Convert);
+    let verify_job = app.jobs.get_job_by_kind(Job::Verify);
+
+    let job_state = convert_job.or(verify_job);
+
+    if let Some(job) = job_state {
+        // Only show modal if job is actually running
+        if job.handle.is_none() || job.handle.as_ref().unwrap().is_finished() {
+            return;
+        }
+
+        let Ok(status) = job.context.status.read() else {
+            return;
+        };
+
+        let modal_id = match job.kind {
+            Job::Convert => "conversion_modal",
+            Job::Verify => "verification_modal",
+            _ => return,
         };
 
         egui::Modal::new(egui::Id::new(modal_id)).show(ctx, |ui| {
             ui.set_min_width(400.0);
             ui.vertical_centered(|ui| {
                 // Header
-                let heading = match operation {
-                    OperationType::Converting => "📦 Converting Files",
-                    OperationType::Verifying => "🔍 Verifying Disc Integrity",
+                let heading = match job.kind {
+                    Job::Convert => "📦 Converting Files",
+                    Job::Verify => "🔍 Verifying Disc Integrity",
+                    _ => "",
                 };
                 ui.heading(heading);
                 ui.separator();
                 ui.add_space(10.0);
 
                 // Show overall progress if processing multiple items
-                if *total_items > 1 {
-                    let item_label = match operation {
-                        OperationType::Converting => "File",
-                        OperationType::Verifying => "Game",
-                    };
-                    ui.label(format!(
-                        "{} {} of {}",
-                        item_label,
-                        items_completed + 1,
-                        total_items
-                    ));
-                    ui.add_space(5.0);
+                if let Some([current_idx, total_items]) = status.progress_items {
+                    if total_items > 1 {
+                        let item_label = match job.kind {
+                            Job::Convert => "File",
+                            Job::Verify => "Game",
+                            _ => "Item",
+                        };
+                        ui.label(format!(
+                            "{} {} of {}",
+                            item_label,
+                            current_idx + 1,
+                            total_items
+                        ));
+                        ui.add_space(5.0);
+                    }
                 }
 
                 // Show current item name
-                if !current_item.is_empty() {
-                    ui.label(egui::RichText::new(current_item).strong());
+                if let Some(item_name) = &status.current_item_name {
+                    ui.label(egui::RichText::new(item_name).strong());
                     ui.add_space(5.0);
                 }
 
                 ui.spinner();
                 ui.add_space(10.0);
 
-                let (current, total) = current_progress;
-                if *total > 0 {
-                    // Calculate combined progress
-                    let base_progress = *items_completed as f32 / *total_items as f32;
-                    let current_item_progress =
-                        (*current as f32 / *total as f32) / *total_items as f32;
-                    let progress_ratio = base_progress + current_item_progress;
+                if let Some([current, total]) = status.progress_bytes {
+                    if total > 0 {
+                        // Use the pre-calculated progress from the job
+                        ui.add(egui::ProgressBar::new(status.progress_percent).show_percentage());
+                        ui.add_space(5.0);
 
-                    ui.add(egui::ProgressBar::new(progress_ratio).show_percentage());
-                    ui.add_space(5.0);
-
-                    ui.label(format!(
-                        "Progress: {} / {}",
-                        Size::from_bytes(*current),
-                        Size::from_bytes(*total)
-                    ));
+                        ui.label(format!(
+                            "Progress: {} / {}",
+                            Size::from_bytes(current),
+                            Size::from_bytes(total)
+                        ));
+                    } else {
+                        let initializing_msg = match job.kind {
+                            Job::Convert => "Initializing conversion...",
+                            Job::Verify => "Initializing verification...",
+                            _ => "Initializing...",
+                        };
+                        ui.label(initializing_msg);
+                    }
                 } else {
-                    let initializing_msg = match operation {
-                        OperationType::Converting => "Initializing conversion...",
-                        OperationType::Verifying => "Initializing verification...",
-                    };
-                    ui.label(initializing_msg);
+                    // No byte progress yet
+                    ui.label(&status.status);
                 }
 
                 ui.add_space(10.0);
 
                 // Cancel button
                 if ui.button("Cancel").clicked() {
-                    let _ = app.inbox.sender().send(BackgroundMessage::CancelOperation);
+                    if let Err(e) = job.cancel.send(()) {
+                        log::error!("Failed to cancel job: {e:?}");
+                    }
                 }
             });
         });

--- a/src/components/operation_modal.rs
+++ b/src/components/operation_modal.rs
@@ -1,104 +1,100 @@
 use crate::app::App;
 use crate::jobs::Job;
 use eframe::egui;
+use log::error;
 use size::Size;
 
 pub fn ui_operation_modal(ctx: &egui::Context, app: &mut App) {
     // Check if conversion or verification job is running
-    let convert_job = app.jobs.get_job_by_kind(Job::Convert);
-    let verify_job = app.jobs.get_job_by_kind(Job::Verify);
+    let Some(job) = app
+        .jobs
+        .get_job_by_kind(Job::Convert)
+        .or_else(|| app.jobs.get_job_by_kind(Job::Verify))
+    else {
+        return;
+    };
+    let Ok(status) = job.context.status.read() else {
+        return;
+    };
 
-    let job_state = convert_job.or(verify_job);
+    let modal_id = match job.kind {
+        Job::Convert => "conversion_modal",
+        Job::Verify => "verification_modal",
+        _ => unreachable!(),
+    };
 
-    if let Some(job) = job_state {
-        // Only show modal if job is actually running
-        if job.handle.is_none() || job.handle.as_ref().unwrap().is_finished() {
-            return;
-        }
+    egui::Modal::new(egui::Id::new(modal_id)).show(ctx, |ui| {
+        ui.set_min_width(400.0);
+        ui.vertical_centered(|ui| {
+            // Header
+            let heading = match job.kind {
+                Job::Convert => "📦 Converting Files",
+                Job::Verify => "🔍 Verifying Disc Integrity",
+                _ => unreachable!(),
+            };
+            ui.heading(heading);
+            ui.separator();
+            ui.add_space(10.0);
 
-        let Ok(status) = job.context.status.read() else {
-            return;
-        };
-
-        let modal_id = match job.kind {
-            Job::Convert => "conversion_modal",
-            Job::Verify => "verification_modal",
-            _ => return,
-        };
-
-        egui::Modal::new(egui::Id::new(modal_id)).show(ctx, |ui| {
-            ui.set_min_width(400.0);
-            ui.vertical_centered(|ui| {
-                // Header
-                let heading = match job.kind {
-                    Job::Convert => "📦 Converting Files",
-                    Job::Verify => "🔍 Verifying Disc Integrity",
-                    _ => "",
+            // Show overall progress if processing multiple items
+            if let Some([current_idx, total_items]) = status.progress_items
+                && total_items > 1
+            {
+                let item_label = match job.kind {
+                    Job::Convert => "File",
+                    Job::Verify => "Game",
+                    _ => "Item",
                 };
-                ui.heading(heading);
-                ui.separator();
-                ui.add_space(10.0);
+                ui.label(format!(
+                    "{} {} of {}",
+                    item_label,
+                    current_idx + 1,
+                    total_items
+                ));
+                ui.add_space(5.0);
+            }
 
-                // Show overall progress if processing multiple items
-                if let Some([current_idx, total_items]) = status.progress_items {
-                    if total_items > 1 {
-                        let item_label = match job.kind {
-                            Job::Convert => "File",
-                            Job::Verify => "Game",
-                            _ => "Item",
-                        };
-                        ui.label(format!(
-                            "{} {} of {}",
-                            item_label,
-                            current_idx + 1,
-                            total_items
-                        ));
-                        ui.add_space(5.0);
-                    }
-                }
+            // Show current item name
+            if let Some(item_name) = &status.current_item_name {
+                ui.label(egui::RichText::new(item_name).strong());
+                ui.add_space(5.0);
+            }
 
-                // Show current item name
-                if let Some(item_name) = &status.current_item_name {
-                    ui.label(egui::RichText::new(item_name).strong());
+            ui.spinner();
+            ui.add_space(10.0);
+
+            if let Some([current, total]) = status.progress_bytes {
+                if total > 0 {
+                    // Use the pre-calculated progress from the job
+                    ui.add(egui::ProgressBar::new(status.progress_percent).show_percentage());
                     ui.add_space(5.0);
-                }
 
-                ui.spinner();
-                ui.add_space(10.0);
-
-                if let Some([current, total]) = status.progress_bytes {
-                    if total > 0 {
-                        // Use the pre-calculated progress from the job
-                        ui.add(egui::ProgressBar::new(status.progress_percent).show_percentage());
-                        ui.add_space(5.0);
-
-                        ui.label(format!(
-                            "Progress: {} / {}",
-                            Size::from_bytes(current),
-                            Size::from_bytes(total)
-                        ));
-                    } else {
-                        let initializing_msg = match job.kind {
-                            Job::Convert => "Initializing conversion...",
-                            Job::Verify => "Initializing verification...",
-                            _ => "Initializing...",
-                        };
-                        ui.label(initializing_msg);
-                    }
+                    ui.label(format!(
+                        "Progress: {} / {}",
+                        Size::from_bytes(current),
+                        Size::from_bytes(total)
+                    ));
                 } else {
-                    // No byte progress yet
-                    ui.label(&status.status);
+                    let initializing_msg = match job.kind {
+                        Job::Convert => "Initializing conversion...",
+                        Job::Verify => "Initializing verification...",
+                        _ => unreachable!(),
+                    };
+                    ui.label(initializing_msg);
                 }
+            } else {
+                // No byte progress yet
+                ui.label(&status.status);
+            }
 
-                ui.add_space(10.0);
+            ui.add_space(10.0);
 
-                // Cancel button
-                if ui.button("Cancel").clicked() {
-                    if let Err(e) = job.cancel.send(()) {
-                        log::error!("Failed to cancel job: {e:?}");
-                    }
-                }
-            });
+            // Cancel button
+            if ui.button("Cancel").clicked()
+                && let Err(e) = job.cancel.send(())
+            {
+                error!("Failed to cancel job: {e:?}");
+            }
         });
-    }
+    });
 }

--- a/src/components/top_panel.rs
+++ b/src/components/top_panel.rs
@@ -5,6 +5,7 @@ use crate::app::App;
 use crate::components::fake_link::fake_link;
 use crate::cover_manager::CoverType;
 use crate::game::VerificationStatus;
+use crate::jobs::{Job, download_covers, download_database, egui_waker};
 use crate::messages::BackgroundMessage;
 use anyhow::anyhow;
 use eframe::egui;
@@ -79,12 +80,17 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                         .clicked()
                         && let Some(cover_manager) = &app.cover_manager
                     {
-                        if let Err(e) = cover_manager.download_database(sender.clone()) {
-                            let _ = sender.send(BackgroundMessage::Error(e));
-                        } else {
-                            app.top_left_toasts
-                                .info("Downloading GameTDB database in background...");
-                        }
+                        let config = download_database::DownloadDatabaseConfig {
+                            base_dir: cover_manager.base_dir().clone(),
+                        };
+                        app.jobs.push_once(Job::DownloadDatabase, || {
+                            download_database::start_download_database(
+                                egui_waker::egui_waker(ctx),
+                                config,
+                            )
+                        });
+                        app.top_left_toasts
+                            .info("Downloading GameTDB database in background...");
                     }
 
                     ui.separator();
@@ -96,11 +102,29 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                         .clicked()
                         && let Some(cover_manager) = &app.cover_manager
                     {
-                        let game_ids: Vec<String> =
-                            app.games.iter().map(|g| g.id.clone()).collect();
-                        cover_manager.download_all_covers(game_ids, CoverType::Cover3D);
-                        app.top_left_toasts
-                            .info("Downloading covers in background...");
+                        let game_ids: Vec<String> = app
+                            .games
+                            .iter()
+                            .map(|g| g.id.clone())
+                            .filter(|id| !cover_manager.has_cover(id, CoverType::Cover3D))
+                            .filter(|id| !cover_manager.is_failed(id, CoverType::Cover3D))
+                            .collect();
+
+                        if !game_ids.is_empty() {
+                            let config = download_covers::DownloadCoversConfig {
+                                base_dir: cover_manager.base_dir().clone(),
+                                cover_type: CoverType::Cover3D,
+                                game_ids,
+                            };
+                            app.jobs.push_once(Job::DownloadCovers, || {
+                                download_covers::start_download_covers(
+                                    egui_waker::egui_waker(ctx),
+                                    config,
+                                )
+                            });
+                            app.top_left_toasts
+                                .info("Downloading covers in background...");
+                        }
                     }
 
                     if ui
@@ -109,11 +133,29 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                         .clicked()
                         && let Some(cover_manager) = &app.cover_manager
                     {
-                        let game_ids: Vec<String> =
-                            app.games.iter().map(|g| g.id.clone()).collect();
-                        cover_manager.download_all_covers(game_ids, CoverType::Cover2D);
-                        app.top_left_toasts
-                            .info("Downloading covers in background...");
+                        let game_ids: Vec<String> = app
+                            .games
+                            .iter()
+                            .map(|g| g.id.clone())
+                            .filter(|id| !cover_manager.has_cover(id, CoverType::Cover2D))
+                            .filter(|id| !cover_manager.is_failed(id, CoverType::Cover2D))
+                            .collect();
+
+                        if !game_ids.is_empty() {
+                            let config = download_covers::DownloadCoversConfig {
+                                base_dir: cover_manager.base_dir().clone(),
+                                cover_type: CoverType::Cover2D,
+                                game_ids,
+                            };
+                            app.jobs.push_once(Job::DownloadCovers, || {
+                                download_covers::start_download_covers(
+                                    egui_waker::egui_waker(ctx),
+                                    config,
+                                )
+                            });
+                            app.top_left_toasts
+                                .info("Downloading covers in background...");
+                        }
                     }
 
                     if ui
@@ -122,11 +164,29 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                         .clicked()
                         && let Some(cover_manager) = &app.cover_manager
                     {
-                        let game_ids: Vec<String> =
-                            app.games.iter().map(|g| g.id.clone()).collect();
-                        cover_manager.download_all_covers(game_ids, CoverType::CoverFull);
-                        app.top_left_toasts
-                            .info("Downloading covers in background...");
+                        let game_ids: Vec<String> = app
+                            .games
+                            .iter()
+                            .map(|g| g.id.clone())
+                            .filter(|id| !cover_manager.has_cover(id, CoverType::CoverFull))
+                            .filter(|id| !cover_manager.is_failed(id, CoverType::CoverFull))
+                            .collect();
+
+                        if !game_ids.is_empty() {
+                            let config = download_covers::DownloadCoversConfig {
+                                base_dir: cover_manager.base_dir().clone(),
+                                cover_type: CoverType::CoverFull,
+                                game_ids,
+                            };
+                            app.jobs.push_once(Job::DownloadCovers, || {
+                                download_covers::start_download_covers(
+                                    egui_waker::egui_waker(ctx),
+                                    config,
+                                )
+                            });
+                            app.top_left_toasts
+                                .info("Downloading covers in background...");
+                        }
                     }
 
                     if ui
@@ -135,11 +195,29 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                         .clicked()
                         && let Some(cover_manager) = &app.cover_manager
                     {
-                        let game_ids: Vec<String> =
-                            app.games.iter().map(|g| g.id.clone()).collect();
-                        cover_manager.download_all_covers(game_ids, CoverType::Disc);
-                        app.top_left_toasts
-                            .info("Downloading covers in background...");
+                        let game_ids: Vec<String> = app
+                            .games
+                            .iter()
+                            .map(|g| g.id.clone())
+                            .filter(|id| !cover_manager.has_cover(id, CoverType::Disc))
+                            .filter(|id| !cover_manager.is_failed(id, CoverType::Disc))
+                            .collect();
+
+                        if !game_ids.is_empty() {
+                            let config = download_covers::DownloadCoversConfig {
+                                base_dir: cover_manager.base_dir().clone(),
+                                cover_type: CoverType::Disc,
+                                game_ids,
+                            };
+                            app.jobs.push_once(Job::DownloadCovers, || {
+                                download_covers::start_download_covers(
+                                    egui_waker::egui_waker(ctx),
+                                    config,
+                                )
+                            });
+                            app.top_left_toasts
+                                .info("Downloading covers in background...");
+                        }
                     }
                 });
             }

--- a/src/components/top_panel.rs
+++ b/src/components/top_panel.rs
@@ -3,6 +3,7 @@
 
 use crate::app::App;
 use crate::components::fake_link::fake_link;
+use crate::cover_manager::CoverType;
 use crate::game::VerificationStatus;
 use crate::messages::BackgroundMessage;
 use anyhow::anyhow;
@@ -67,6 +68,80 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                 if verify_all_button.clicked() {
                     app.start_verify_all();
                 }
+
+                // GameTDB menu
+                ui.label("•");
+                ui.menu_button("🎮 GameTDB", |ui| {
+                    // Download database option
+                    if ui
+                        .button("📥 Download GameTDB Database")
+                        .on_hover_text("Download the latest wiitdb.xml database from GameTDB")
+                        .clicked()
+                        && let Some(cover_manager) = &app.cover_manager
+                    {
+                        if let Err(e) = cover_manager.download_database() {
+                            let _ = sender.send(BackgroundMessage::Error(e));
+                        } else {
+                            app.top_left_toasts
+                                .info("Downloading GameTDB database in background...");
+                        }
+                    }
+
+                    ui.separator();
+
+                    // Download all covers options
+                    if ui
+                        .button("📥 Download All 3D Covers")
+                        .on_hover_text("Download 3D covers for all games")
+                        .clicked()
+                        && let Some(cover_manager) = &app.cover_manager
+                    {
+                        let game_ids: Vec<String> =
+                            app.games.iter().map(|g| g.id.clone()).collect();
+                        cover_manager.download_all_covers(game_ids, CoverType::Cover3D);
+                        app.top_left_toasts
+                            .info("Downloading covers in background...");
+                    }
+
+                    if ui
+                        .button("📥 Download All 2D Covers")
+                        .on_hover_text("Download 2D covers for all games")
+                        .clicked()
+                        && let Some(cover_manager) = &app.cover_manager
+                    {
+                        let game_ids: Vec<String> =
+                            app.games.iter().map(|g| g.id.clone()).collect();
+                        cover_manager.download_all_covers(game_ids, CoverType::Cover2D);
+                        app.top_left_toasts
+                            .info("Downloading covers in background...");
+                    }
+
+                    if ui
+                        .button("📥 Download All Full Covers")
+                        .on_hover_text("Download full covers for all games")
+                        .clicked()
+                        && let Some(cover_manager) = &app.cover_manager
+                    {
+                        let game_ids: Vec<String> =
+                            app.games.iter().map(|g| g.id.clone()).collect();
+                        cover_manager.download_all_covers(game_ids, CoverType::CoverFull);
+                        app.top_left_toasts
+                            .info("Downloading covers in background...");
+                    }
+
+                    if ui
+                        .button("📥 Download All Disc Art")
+                        .on_hover_text("Download disc art for all games")
+                        .clicked()
+                        && let Some(cover_manager) = &app.cover_manager
+                    {
+                        let game_ids: Vec<String> =
+                            app.games.iter().map(|g| g.id.clone()).collect();
+                        cover_manager.download_all_covers(game_ids, CoverType::Disc);
+                        app.top_left_toasts
+                            .info("Downloading covers in background...");
+                    }
+                });
             }
 
             // Tests (only debug builds)

--- a/src/components/top_panel.rs
+++ b/src/components/top_panel.rs
@@ -75,7 +75,7 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                 ui.menu_button("🎮 GameTDB", |ui| {
                     // Download database option
                     if ui
-                        .button("📥 Download GameTDB Database")
+                        .button("📥 Update GameTDB Database")
                         .on_hover_text("Download the latest wiitdb.xml database from GameTDB")
                         .clicked()
                         && let Some(cover_manager) = &app.cover_manager
@@ -90,7 +90,7 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                             )
                         });
                         app.bottom_right_toasts
-                            .info("Downloading GameTDB database...");
+                            .info("Updating GameTDB database...");
                     }
 
                     ui.separator();

--- a/src/components/top_panel.rs
+++ b/src/components/top_panel.rs
@@ -89,8 +89,7 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                                 config,
                             )
                         });
-                        app.bottom_right_toasts
-                            .info("Updating GameTDB database...");
+                        app.bottom_right_toasts.info("Updating GameTDB database...");
                     }
 
                     ui.separator();

--- a/src/components/top_panel.rs
+++ b/src/components/top_panel.rs
@@ -96,145 +96,10 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                     ui.separator();
 
                     // Download all covers options
-                    if ui
-                        .button("📥 Download All 3D Covers")
-                        .on_hover_text("Download 3D covers for all games")
-                        .clicked()
-                        && let Some(cover_manager) = &app.cover_manager
-                    {
-                        let game_ids: Vec<String> = app
-                            .games
-                            .iter()
-                            .map(|g| g.id.clone())
-                            .filter(|id| !cover_manager.has_cover(id, CoverType::Cover3D))
-                            .filter(|id| !cover_manager.is_failed(id, CoverType::Cover3D))
-                            .collect();
-
-                        if game_ids.is_empty() {
-                            app.bottom_right_toasts
-                                .info("All 3D covers already downloaded.");
-                        } else {
-                            let num_covers = game_ids.len();
-                            let config = download_covers::DownloadCoversConfig {
-                                base_dir: cover_manager.base_dir().clone(),
-                                cover_type: CoverType::Cover3D,
-                                game_ids,
-                            };
-                            app.jobs.push_once(Job::DownloadCovers, || {
-                                download_covers::start_download_covers(
-                                    egui_waker::egui_waker(ctx),
-                                    config,
-                                )
-                            });
-                            app.bottom_right_toasts
-                                .info(format!("Downloading 3D covers for {num_covers} games..."));
-                        }
-                    }
-
-                    if ui
-                        .button("📥 Download All 2D Covers")
-                        .on_hover_text("Download 2D covers for all games")
-                        .clicked()
-                        && let Some(cover_manager) = &app.cover_manager
-                    {
-                        let game_ids: Vec<String> = app
-                            .games
-                            .iter()
-                            .map(|g| g.id.clone())
-                            .filter(|id| !cover_manager.has_cover(id, CoverType::Cover2D))
-                            .filter(|id| !cover_manager.is_failed(id, CoverType::Cover2D))
-                            .collect();
-
-                        if game_ids.is_empty() {
-                            app.bottom_right_toasts
-                                .info("All 2D covers already downloaded.");
-                        } else {
-                            let num_covers = game_ids.len();
-                            let config = download_covers::DownloadCoversConfig {
-                                base_dir: cover_manager.base_dir().clone(),
-                                cover_type: CoverType::Cover2D,
-                                game_ids,
-                            };
-                            app.jobs.push_once(Job::DownloadCovers, || {
-                                download_covers::start_download_covers(
-                                    egui_waker::egui_waker(ctx),
-                                    config,
-                                )
-                            });
-                            app.bottom_right_toasts
-                                .info(format!("Downloading 2D covers for {num_covers} games..."));
-                        }
-                    }
-
-                    if ui
-                        .button("📥 Download All Full Covers")
-                        .on_hover_text("Download full covers for all games")
-                        .clicked()
-                        && let Some(cover_manager) = &app.cover_manager
-                    {
-                        let game_ids: Vec<String> = app
-                            .games
-                            .iter()
-                            .map(|g| g.id.clone())
-                            .filter(|id| !cover_manager.has_cover(id, CoverType::CoverFull))
-                            .filter(|id| !cover_manager.is_failed(id, CoverType::CoverFull))
-                            .collect();
-
-                        if game_ids.is_empty() {
-                            app.bottom_right_toasts
-                                .info("All full covers already downloaded.");
-                        } else {
-                            let num_covers = game_ids.len();
-                            let config = download_covers::DownloadCoversConfig {
-                                base_dir: cover_manager.base_dir().clone(),
-                                cover_type: CoverType::CoverFull,
-                                game_ids,
-                            };
-                            app.jobs.push_once(Job::DownloadCovers, || {
-                                download_covers::start_download_covers(
-                                    egui_waker::egui_waker(ctx),
-                                    config,
-                                )
-                            });
-                            app.bottom_right_toasts
-                                .info(format!("Downloading full covers for {num_covers} games..."));
-                        }
-                    }
-
-                    if ui
-                        .button("📥 Download All Disc Art")
-                        .on_hover_text("Download disc art for all games")
-                        .clicked()
-                        && let Some(cover_manager) = &app.cover_manager
-                    {
-                        let game_ids: Vec<String> = app
-                            .games
-                            .iter()
-                            .map(|g| g.id.clone())
-                            .filter(|id| !cover_manager.has_cover(id, CoverType::Disc))
-                            .filter(|id| !cover_manager.is_failed(id, CoverType::Disc))
-                            .collect();
-
-                        if game_ids.is_empty() {
-                            app.bottom_right_toasts
-                                .info("All disc art already downloaded.");
-                        } else {
-                            let num_covers = game_ids.len();
-                            let config = download_covers::DownloadCoversConfig {
-                                base_dir: cover_manager.base_dir().clone(),
-                                cover_type: CoverType::Disc,
-                                game_ids,
-                            };
-                            app.jobs.push_once(Job::DownloadCovers, || {
-                                download_covers::start_download_covers(
-                                    egui_waker::egui_waker(ctx),
-                                    config,
-                                )
-                            });
-                            app.bottom_right_toasts
-                                .info(format!("Downloading disc art for {num_covers} games..."));
-                        }
-                    }
+                    download_covers_ui(ui, ctx, app, CoverType::Cover3D);
+                    download_covers_ui(ui, ctx, app, CoverType::Cover2D);
+                    download_covers_ui(ui, ctx, app, CoverType::CoverFull);
+                    download_covers_ui(ui, ctx, app, CoverType::Disc);
                 });
             }
 
@@ -285,4 +150,52 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
             });
         });
     });
+}
+
+/// Helper function to handle downloading covers of a specific type
+fn download_covers_ui(
+    ui: &mut egui::Ui,
+    ctx: &egui::Context,
+    app: &mut App,
+    cover_type: CoverType,
+) {
+    let cover_type_name = match cover_type {
+        CoverType::Cover3D => "3D covers",
+        CoverType::Cover2D => "2D covers",
+        CoverType::CoverFull => "full covers",
+        CoverType::Disc => "disc art",
+    };
+    if ui
+        .button(format!("📥 Download all {cover_type_name}"))
+        .on_hover_text(format!("Download {cover_type_name} for all games"))
+        .clicked()
+        && let Some(cover_manager) = &app.cover_manager
+    {
+        let game_ids: Vec<String> = app
+            .games
+            .iter()
+            .map(|g| g.id.clone())
+            .filter(|id| !cover_manager.has_cover(id, cover_type))
+            .filter(|id| !cover_manager.is_failed(id, cover_type))
+            .collect();
+
+        if game_ids.is_empty() {
+            app.bottom_right_toasts
+                .info(format!("All {} already downloaded.", cover_type_name));
+        } else {
+            let num_covers = game_ids.len();
+            let config = download_covers::DownloadCoversConfig {
+                base_dir: cover_manager.base_dir().clone(),
+                cover_type,
+                game_ids,
+            };
+            app.jobs.push_once(Job::DownloadCovers, || {
+                download_covers::start_download_covers(egui_waker::egui_waker(ctx), config)
+            });
+            app.bottom_right_toasts.info(format!(
+                "Downloading {} for {} games...",
+                cover_type_name, num_covers
+            ));
+        }
+    }
 }

--- a/src/components/top_panel.rs
+++ b/src/components/top_panel.rs
@@ -79,7 +79,7 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                         .clicked()
                         && let Some(cover_manager) = &app.cover_manager
                     {
-                        if let Err(e) = cover_manager.download_database() {
+                        if let Err(e) = cover_manager.download_database(sender.clone()) {
                             let _ = sender.send(BackgroundMessage::Error(e));
                         } else {
                             app.top_left_toasts

--- a/src/components/top_panel.rs
+++ b/src/components/top_panel.rs
@@ -89,8 +89,8 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                                 config,
                             )
                         });
-                        app.top_left_toasts
-                            .info("Downloading GameTDB database in background...");
+                        app.bottom_right_toasts
+                            .info("Downloading GameTDB database...");
                     }
 
                     ui.separator();
@@ -110,7 +110,11 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                             .filter(|id| !cover_manager.is_failed(id, CoverType::Cover3D))
                             .collect();
 
-                        if !game_ids.is_empty() {
+                        if game_ids.is_empty() {
+                            app.bottom_right_toasts
+                                .info("All 3D covers already downloaded.");
+                        } else {
+                            let num_covers = game_ids.len();
                             let config = download_covers::DownloadCoversConfig {
                                 base_dir: cover_manager.base_dir().clone(),
                                 cover_type: CoverType::Cover3D,
@@ -122,8 +126,8 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                                     config,
                                 )
                             });
-                            app.top_left_toasts
-                                .info("Downloading covers in background...");
+                            app.bottom_right_toasts
+                                .info(format!("Downloading 3D covers for {num_covers} games..."));
                         }
                     }
 
@@ -141,7 +145,11 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                             .filter(|id| !cover_manager.is_failed(id, CoverType::Cover2D))
                             .collect();
 
-                        if !game_ids.is_empty() {
+                        if game_ids.is_empty() {
+                            app.bottom_right_toasts
+                                .info("All 2D covers already downloaded.");
+                        } else {
+                            let num_covers = game_ids.len();
                             let config = download_covers::DownloadCoversConfig {
                                 base_dir: cover_manager.base_dir().clone(),
                                 cover_type: CoverType::Cover2D,
@@ -153,8 +161,8 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                                     config,
                                 )
                             });
-                            app.top_left_toasts
-                                .info("Downloading covers in background...");
+                            app.bottom_right_toasts
+                                .info(format!("Downloading 2D covers for {num_covers} games..."));
                         }
                     }
 
@@ -172,7 +180,11 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                             .filter(|id| !cover_manager.is_failed(id, CoverType::CoverFull))
                             .collect();
 
-                        if !game_ids.is_empty() {
+                        if game_ids.is_empty() {
+                            app.bottom_right_toasts
+                                .info("All full covers already downloaded.");
+                        } else {
+                            let num_covers = game_ids.len();
                             let config = download_covers::DownloadCoversConfig {
                                 base_dir: cover_manager.base_dir().clone(),
                                 cover_type: CoverType::CoverFull,
@@ -184,8 +196,8 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                                     config,
                                 )
                             });
-                            app.top_left_toasts
-                                .info("Downloading covers in background...");
+                            app.bottom_right_toasts
+                                .info(format!("Downloading full covers for {num_covers} games..."));
                         }
                     }
 
@@ -203,7 +215,11 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                             .filter(|id| !cover_manager.is_failed(id, CoverType::Disc))
                             .collect();
 
-                        if !game_ids.is_empty() {
+                        if game_ids.is_empty() {
+                            app.bottom_right_toasts
+                                .info("All disc art already downloaded.");
+                        } else {
+                            let num_covers = game_ids.len();
                             let config = download_covers::DownloadCoversConfig {
                                 base_dir: cover_manager.base_dir().clone(),
                                 cover_type: CoverType::Disc,
@@ -215,8 +231,8 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                                     config,
                                 )
                             });
-                            app.top_left_toasts
-                                .info("Downloading covers in background...");
+                            app.bottom_right_toasts
+                                .info(format!("Downloading disc art for {num_covers} games..."));
                         }
                     }
                 });
@@ -227,7 +243,11 @@ pub fn ui_top_panel(ctx: &egui::Context, app: &mut App) {
                 ui.label("•");
                 ui.menu_button("🛠 Tests", |ui| {
                     if ui.button("❌ Test Error").clicked() {
-                        let _ = sender.send(BackgroundMessage::Error(anyhow!("Test error")));
+                        let _ = sender.send(BackgroundMessage::Error(
+                            anyhow!("Test error")
+                                .context("Doing something")
+                                .context("In ui_top_panel"),
+                        ));
                     }
 
                     if ui.button("❌ Test Error 2").clicked() {

--- a/src/cover_manager.rs
+++ b/src/cover_manager.rs
@@ -1,0 +1,287 @@
+// SPDX-FileCopyrightText: 2025 Manuel Quarneti <mq1@ik.me>
+// SPDX-License-Identifier: GPL-2.0-only
+
+use crate::messages::BackgroundMessage;
+use anyhow::{Context, Result};
+use egui_inbox::UiInboxSender;
+use phf::phf_map;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+// A static map to convert the region character from a game's ID to a language code
+// used by the GameTDB API for fetching cover art.
+static REGION_TO_LANG: phf::Map<char, &'static str> = phf_map! {
+    'A' => "EN", // System Wii Channels (i.e. Mii Channel)
+    'B' => "EN", // Ufouria: The Saga (NA)
+    'D' => "DE", // Germany
+    'E' => "US", // USA
+    'F' => "FR", // France
+    'H' => "NL", // Netherlands
+    'I' => "IT", // Italy
+    'J' => "JA", // Japan
+    'K' => "KO", // Korea
+    'L' => "EN", // Japanese import to Europe, Australia and other PAL regions
+    'M' => "EN", // American import to Europe, Australia and other PAL regions
+    'N' => "US", // Japanese import to USA and other NTSC regions
+    'P' => "EN", // Europe and other PAL regions such as Australia
+    'Q' => "KO", // Japanese Virtual Console import to Korea
+    'R' => "RU", // Russia
+    'S' => "ES", // Spain
+    'T' => "KO", // American Virtual Console import to Korea
+    'U' => "EN", // Australia / Europe alternate languages
+    'V' => "EN", // Scandinavia
+    'W' => "ZH", // Republic of China (Taiwan) / Hong Kong / Macau
+    'X' => "EN", // Europe alternate languages / US special releases
+    'Y' => "EN", // Europe alternate languages / US special releases
+    'Z' => "EN", // Europe alternate languages / US special releases
+};
+
+/// Types of cover art available from GameTDB
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CoverType {
+    /// 3D box art (default)
+    Cover3D,
+    /// 2D flat cover art
+    Cover2D,
+    /// Full cover art (front + back)
+    CoverFull,
+    /// Disc art
+    Disc,
+}
+
+impl CoverType {
+    /// Get the subdirectory name for this cover type in USB Loader GX structure
+    pub fn subdirectory(&self) -> &'static str {
+        match self {
+            CoverType::Cover3D => "images",
+            CoverType::Cover2D => "images/2D",
+            CoverType::CoverFull => "images/full",
+            CoverType::Disc => "images/disc",
+        }
+    }
+
+    /// Get the GameTDB API endpoint for this cover type
+    pub fn api_endpoint(&self) -> &'static str {
+        match self {
+            CoverType::Cover3D => "cover3D",
+            CoverType::Cover2D => "cover",
+            CoverType::CoverFull => "coverfull",
+            CoverType::Disc => "disc",
+        }
+    }
+}
+
+/// Manages downloading and caching of game cover art from GameTDB
+pub struct CoverManager {
+    base_dir: PathBuf,
+    /// Track which covers are currently being downloaded to avoid duplicates
+    downloading: Arc<Mutex<HashSet<(String, CoverType)>>>,
+}
+
+impl CoverManager {
+    /// Create a new CoverManager with the given base directory
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self {
+            base_dir,
+            downloading: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// Get the local path where a cover should be stored for USB Loader GX compatibility
+    pub fn get_cover_path(&self, game_id: &str, cover_type: CoverType) -> PathBuf {
+        self.base_dir
+            .join("apps/usbloader_gx")
+            .join(cover_type.subdirectory())
+            .join(format!("{}.png", game_id))
+    }
+
+    /// Check if a cover exists locally
+    pub fn has_cover(&self, game_id: &str, cover_type: CoverType) -> bool {
+        self.get_cover_path(game_id, cover_type).exists()
+    }
+
+    /// Check if a cover is currently being downloaded
+    pub fn is_downloading(&self, game_id: &str, cover_type: CoverType) -> bool {
+        self.downloading
+            .lock()
+            .unwrap()
+            .contains(&(game_id.to_string(), cover_type))
+    }
+
+    /// Queue a cover download in a background thread
+    pub fn queue_download(
+        &self,
+        game_id: String,
+        cover_type: CoverType,
+        sender: UiInboxSender<BackgroundMessage>,
+    ) {
+        // Check if already downloading
+        {
+            let mut downloading = self.downloading.lock().unwrap();
+            let key = (game_id.clone(), cover_type);
+            if downloading.contains(&key) {
+                return; // Already downloading
+            }
+            downloading.insert(key);
+        }
+
+        // Check if file already exists
+        if self.has_cover(&game_id, cover_type) {
+            // File exists, remove from downloading set and return
+            self.downloading
+                .lock()
+                .unwrap()
+                .remove(&(game_id, cover_type));
+            return;
+        }
+
+        let base_dir = self.base_dir.clone();
+        let downloading = Arc::clone(&self.downloading);
+
+        thread::spawn(move || {
+            let result = Self::download_cover(&base_dir, &game_id, cover_type);
+            
+            // Remove from downloading set
+            downloading
+                .lock()
+                .unwrap()
+                .remove(&(game_id.clone(), cover_type));
+
+            // Send result to UI
+            match result {
+                Ok(path) => {
+                    let _ = sender.send(BackgroundMessage::CoverDownloaded {
+                        game_id,
+                        cover_type,
+                        path,
+                    });
+                }
+                Err(e) => {
+                    log::debug!("Failed to download cover for {}: {}", game_id, e);
+                    let _ = sender.send(BackgroundMessage::CoverDownloadFailed {
+                        game_id,
+                        cover_type,
+                        error: e.to_string(),
+                    });
+                }
+            }
+        });
+    }
+
+    /// Download a cover from GameTDB API (blocking operation)
+    fn download_cover(
+        base_dir: &Path,
+        game_id: &str,
+        cover_type: CoverType,
+    ) -> Result<PathBuf> {
+        // Determine language from game ID region
+        let region_char = game_id.chars().nth(3)
+            .context("Game ID too short to determine region")?;
+        let language = REGION_TO_LANG.get(&region_char).unwrap_or(&"EN");
+
+        // Construct GameTDB API URL
+        let url = format!(
+            "https://art.gametdb.com/wii/{}/{}/{}.png",
+            cover_type.api_endpoint(),
+            language,
+            game_id
+        );
+
+        // Create target directory structure
+        let target_path = base_dir
+            .join("apps/usbloader_gx")
+            .join(cover_type.subdirectory())
+            .join(format!("{}.png", game_id));
+        
+        if let Some(parent) = target_path.parent() {
+            std::fs::create_dir_all(parent)
+                .context("Failed to create cover directory")?;
+        }
+
+        // Download the cover
+        log::debug!("Downloading cover from: {}", url);
+        let response = reqwest::blocking::get(&url)
+            .context("Failed to send HTTP request")?;
+
+        if response.status().is_success() {
+            let bytes = response.bytes()
+                .context("Failed to read response body")?;
+            
+            std::fs::write(&target_path, bytes)
+                .context("Failed to write cover file")?;
+            
+            log::info!("Downloaded cover: {:?}", target_path);
+            Ok(target_path)
+        } else {
+            anyhow::bail!("HTTP error: {}", response.status());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_cover_type_subdirectory() {
+        assert_eq!(CoverType::Cover3D.subdirectory(), "images");
+        assert_eq!(CoverType::Cover2D.subdirectory(), "images/2D");
+        assert_eq!(CoverType::CoverFull.subdirectory(), "images/full");
+        assert_eq!(CoverType::Disc.subdirectory(), "images/disc");
+    }
+
+    #[test]
+    fn test_cover_type_api_endpoint() {
+        assert_eq!(CoverType::Cover3D.api_endpoint(), "cover3D");
+        assert_eq!(CoverType::Cover2D.api_endpoint(), "cover");
+        assert_eq!(CoverType::CoverFull.api_endpoint(), "coverfull");
+        assert_eq!(CoverType::Disc.api_endpoint(), "disc");
+    }
+
+    #[test]
+    fn test_get_cover_path() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = CoverManager::new(temp_dir.path().to_path_buf());
+
+        let path = manager.get_cover_path("RMGE01", CoverType::Cover3D);
+        assert_eq!(
+            path,
+            temp_dir.path().join("apps/usbloader_gx/images/RMGE01.png")
+        );
+
+        let path = manager.get_cover_path("RMGE01", CoverType::Cover2D);
+        assert_eq!(
+            path,
+            temp_dir.path().join("apps/usbloader_gx/images/2D/RMGE01.png")
+        );
+    }
+
+    #[test]
+    fn test_has_cover() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = CoverManager::new(temp_dir.path().to_path_buf());
+
+        // Initially no cover
+        assert!(!manager.has_cover("RMGE01", CoverType::Cover3D));
+
+        // Create the cover file
+        let cover_path = manager.get_cover_path("RMGE01", CoverType::Cover3D);
+        fs::create_dir_all(cover_path.parent().unwrap()).unwrap();
+        fs::write(&cover_path, b"fake image data").unwrap();
+
+        // Now it should exist
+        assert!(manager.has_cover("RMGE01", CoverType::Cover3D));
+    }
+
+    #[test]
+    fn test_region_to_language_mapping() {
+        assert_eq!(REGION_TO_LANG.get(&'E'), Some(&"US"));
+        assert_eq!(REGION_TO_LANG.get(&'P'), Some(&"EN"));
+        assert_eq!(REGION_TO_LANG.get(&'J'), Some(&"JA"));
+        assert_eq!(REGION_TO_LANG.get(&'D'), Some(&"DE"));
+    }
+}

--- a/src/cover_manager.rs
+++ b/src/cover_manager.rs
@@ -142,7 +142,7 @@ impl CoverManager {
 
         thread::spawn(move || {
             let result = Self::download_cover(&base_dir, &game_id, cover_type);
-            
+
             // Remove from downloading set
             downloading
                 .lock()
@@ -171,13 +171,11 @@ impl CoverManager {
     }
 
     /// Download a cover from GameTDB API (blocking operation)
-    fn download_cover(
-        base_dir: &Path,
-        game_id: &str,
-        cover_type: CoverType,
-    ) -> Result<PathBuf> {
+    fn download_cover(base_dir: &Path, game_id: &str, cover_type: CoverType) -> Result<PathBuf> {
         // Determine language from game ID region
-        let region_char = game_id.chars().nth(3)
+        let region_char = game_id
+            .chars()
+            .nth(3)
             .context("Game ID too short to determine region")?;
         let language = REGION_TO_LANG.get(&region_char).unwrap_or(&"EN");
 
@@ -194,24 +192,20 @@ impl CoverManager {
             .join("apps/usbloader_gx")
             .join(cover_type.subdirectory())
             .join(format!("{}.png", game_id));
-        
+
         if let Some(parent) = target_path.parent() {
-            std::fs::create_dir_all(parent)
-                .context("Failed to create cover directory")?;
+            std::fs::create_dir_all(parent).context("Failed to create cover directory")?;
         }
 
         // Download the cover
         log::debug!("Downloading cover from: {}", url);
-        let response = reqwest::blocking::get(&url)
-            .context("Failed to send HTTP request")?;
+        let response = reqwest::blocking::get(&url).context("Failed to send HTTP request")?;
 
         if response.status().is_success() {
-            let bytes = response.bytes()
-                .context("Failed to read response body")?;
-            
-            std::fs::write(&target_path, bytes)
-                .context("Failed to write cover file")?;
-            
+            let bytes = response.bytes().context("Failed to read response body")?;
+
+            std::fs::write(&target_path, bytes).context("Failed to write cover file")?;
+
             log::info!("Downloaded cover: {:?}", target_path);
             Ok(target_path)
         } else {
@@ -256,7 +250,9 @@ mod tests {
         let path = manager.get_cover_path("RMGE01", CoverType::Cover2D);
         assert_eq!(
             path,
-            temp_dir.path().join("apps/usbloader_gx/images/2D/RMGE01.png")
+            temp_dir
+                .path()
+                .join("apps/usbloader_gx/images/2D/RMGE01.png")
         );
     }
 

--- a/src/cover_manager.rs
+++ b/src/cover_manager.rs
@@ -1,17 +1,6 @@
-// SPDX-FileCopyrightText: 2025 Manuel Quarneti <mq1@ik.me>
-// SPDX-License-Identifier: GPL-2.0-only
-
-use crate::messages::BackgroundMessage;
-use crate::util::regions::REGION_TO_LANG;
-use anyhow::{Context, Result};
-use egui_inbox::UiInboxSender;
 use std::collections::HashSet;
-use std::fs::File;
-use std::io::{BufReader, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::{fs, thread};
-use tempfile::NamedTempFile;
 
 /// Types of cover art available from GameTDB
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -48,11 +37,11 @@ impl CoverType {
     }
 }
 
-/// Manages downloading and caching of game cover art from GameTDB
+/// Manages game cover art from GameTDB
 pub struct CoverManager {
     base_dir: PathBuf,
-    /// Track which covers are currently being downloaded to avoid duplicates
-    downloading: Arc<Mutex<HashSet<(String, CoverType)>>>,
+    /// Track which covers have permanently failed (404s)
+    failed: Arc<Mutex<HashSet<(String, CoverType)>>>,
 }
 
 impl CoverManager {
@@ -60,7 +49,7 @@ impl CoverManager {
     pub fn new(base_dir: PathBuf) -> Self {
         Self {
             base_dir,
-            downloading: Arc::new(Mutex::new(HashSet::new())),
+            failed: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -77,199 +66,25 @@ impl CoverManager {
         self.get_cover_path(game_id, cover_type).exists()
     }
 
-    /// Check if a cover is currently being downloaded
-    pub fn is_downloading(&self, game_id: &str, cover_type: CoverType) -> bool {
-        self.downloading
+    /// Check if a cover has permanently failed (404)
+    pub fn is_failed(&self, game_id: &str, cover_type: CoverType) -> bool {
+        self.failed
             .lock()
             .unwrap()
             .contains(&(game_id.to_string(), cover_type))
     }
 
-    /// Queue a cover download in a background thread
-    pub fn queue_download(&self, game_id: String, cover_type: CoverType) {
-        // Check if already downloading
-        {
-            let mut downloading = self.downloading.lock().unwrap();
-            let key = (game_id.clone(), cover_type);
-            if downloading.contains(&key) {
-                return; // Already downloading
-            }
-            downloading.insert(key);
-        }
-
-        // Check if file already exists
-        if self.has_cover(&game_id, cover_type) {
-            // File exists, remove from downloading set and return
-            self.downloading
-                .lock()
-                .unwrap()
-                .remove(&(game_id, cover_type));
-            return;
-        }
-
-        let base_dir = self.base_dir.clone();
-        let downloading = Arc::clone(&self.downloading);
-
-        thread::spawn(move || {
-            let result = Self::download_cover(&base_dir, &game_id, cover_type);
-
-            // Remove from downloading set
-            downloading
-                .lock()
-                .unwrap()
-                .remove(&(game_id.clone(), cover_type));
-
-            // Log result
-            match result {
-                Ok(path) => {
-                    log::info!("Downloaded cover for {} to {:?}", game_id, path);
-                }
-                Err(e) => {
-                    // Log as debug since cover download failures are not critical
-                    log::debug!("Failed to download cover for {}: {}", game_id, e);
-                }
-            }
-        });
-    }
-
-    /// Download covers for multiple games
-    pub fn download_all_covers(&self, game_ids: Vec<String>, cover_type: CoverType) {
+    /// Mark covers as permanently failed (404s)
+    pub fn mark_failed(&self, game_ids: Vec<String>, cover_type: CoverType) {
+        let mut failed = self.failed.lock().unwrap();
         for game_id in game_ids {
-            self.queue_download(game_id, cover_type);
+            failed.insert((game_id, cover_type));
         }
     }
 
-    /// Download the GameTDB database (wiitdb.xml) in a background thread
-    pub fn download_database(&self, sender: UiInboxSender<BackgroundMessage>) -> Result<()> {
-        let base_dir = self.base_dir.clone();
-
-        thread::spawn(move || match Self::download_database_blocking(&base_dir) {
-            Ok(path) => {
-                log::info!("Successfully downloaded GameTDB database to {:?}", path);
-                let _ = sender.send(BackgroundMessage::GameTDBDownloadComplete);
-            }
-            Err(e) => {
-                log::error!("Failed to download GameTDB database: {}", e);
-                let _ = sender.send(BackgroundMessage::Error(e));
-            }
-        });
-
-        Ok(())
-    }
-
-    /// Download the GameTDB database (blocking operation)
-    fn download_database_blocking(base_dir: &Path) -> Result<PathBuf> {
-        log::info!("Downloading GameTDB database from https://www.gametdb.com/wiitdb.zip");
-
-        // Download the zip file to a temporary file
-        let mut temp_zip =
-            NamedTempFile::new().context("Failed to create temporary file for zip")?;
-
-        let response = reqwest::blocking::get("https://www.gametdb.com/wiitdb.zip")
-            .context("Failed to download wiitdb.zip")?;
-
-        if !response.status().is_success() {
-            anyhow::bail!("HTTP error downloading wiitdb.zip: {}", response.status());
-        }
-
-        let bytes = response
-            .bytes()
-            .context("Failed to read wiitdb.zip response")?;
-
-        temp_zip
-            .write_all(&bytes)
-            .context("Failed to write temporary zip file")?;
-        temp_zip
-            .flush()
-            .context("Failed to flush temporary zip file")?;
-
-        // Create target directory
-        let target_dir = base_dir.join("apps/usbloader_gx");
-        fs::create_dir_all(&target_dir).context("Failed to create usbloader_gx directory")?;
-
-        // Extract the zip file
-        let file = File::open(temp_zip.path()).context("Failed to open temporary zip file")?;
-        let mut archive =
-            zip::ZipArchive::new(BufReader::new(file)).context("Failed to read zip archive")?;
-
-        // Look for wiitdb.xml in the archive
-        for i in 0..archive.len() {
-            let mut file = archive.by_index(i).context("Failed to access zip entry")?;
-            let name = file.name();
-
-            // Only extract wiitdb.xml
-            if name == "wiitdb.xml" || name.ends_with("/wiitdb.xml") {
-                // Extract directly to the target location
-                let target_path = target_dir.join("wiitdb.xml");
-                let mut outfile = File::create(&target_path)
-                    .context("Failed to create wiitdb.xml")?;
-                std::io::copy(&mut file, &mut outfile)
-                    .context("Failed to extract wiitdb.xml")?;
-                outfile.flush()
-                    .context("Failed to flush wiitdb.xml")?;
-
-                log::info!("Successfully installed wiitdb.xml to {:?}", target_path);
-                return Ok(target_path);
-            }
-        }
-
-        anyhow::bail!("wiitdb.xml not found in downloaded archive")
-    }
-
-    /// Download a cover from GameTDB API (blocking operation)
-    fn download_cover(base_dir: &Path, game_id: &str, cover_type: CoverType) -> Result<PathBuf> {
-        // Determine language from game ID region
-        let region_char = game_id
-            .chars()
-            .nth(3)
-            .context("Game ID too short to determine region")?;
-        let language = REGION_TO_LANG.get(&region_char).unwrap_or(&"EN");
-
-        // Construct GameTDB API URL
-        let url = format!(
-            "https://art.gametdb.com/wii/{}/{}/{}.png",
-            cover_type.api_endpoint(),
-            language,
-            game_id
-        );
-
-        // Download the cover to a temporary file
-        log::debug!("Downloading cover from: {}", url);
-        let response = reqwest::blocking::get(&url).context("Failed to send HTTP request")?;
-
-        if !response.status().is_success() {
-            anyhow::bail!("HTTP error: {}", response.status());
-        }
-
-        let bytes = response.bytes().context("Failed to read response body")?;
-
-        // Write to temporary file first
-        let mut temp_file =
-            NamedTempFile::new().context("Failed to create temporary file for cover")?;
-        temp_file
-            .write_all(&bytes)
-            .context("Failed to write cover to temporary file")?;
-        temp_file
-            .flush()
-            .context("Failed to flush temporary file")?;
-
-        // Create target directory structure
-        let target_path = base_dir
-            .join("apps/usbloader_gx")
-            .join(cover_type.subdirectory())
-            .join(format!("{}.png", game_id));
-
-        if let Some(parent) = target_path.parent() {
-            fs::create_dir_all(parent).context("Failed to create cover directory")?;
-        }
-
-        // Copy to final location (safer than persist for cross-filesystem)
-        fs::copy(temp_file.path(), &target_path)
-            .context("Failed to copy cover to final location")?;
-        // temp_file will be automatically cleaned up when dropped
-
-        log::info!("Downloaded cover: {:?}", target_path);
-        Ok(target_path)
+    /// Get the base directory
+    pub fn base_dir(&self) -> &PathBuf {
+        &self.base_dir
     }
 }
 
@@ -330,13 +145,5 @@ mod tests {
 
         // Now it should exist
         assert!(manager.has_cover("RMGE01", CoverType::Cover3D));
-    }
-
-    #[test]
-    fn test_region_to_language_mapping() {
-        assert_eq!(REGION_TO_LANG.get(&'E'), Some(&"US"));
-        assert_eq!(REGION_TO_LANG.get(&'P'), Some(&"EN"));
-        assert_eq!(REGION_TO_LANG.get(&'J'), Some(&"JA"));
-        assert_eq!(REGION_TO_LANG.get(&'D'), Some(&"DE"));
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -112,16 +112,11 @@ impl Game {
         let (id, title) = Self::parse_filename(&path)?;
 
         // Try GameTDB first, then fall back to built-in titles, then the parsed title
-        let display_title = if let Some(base_dir) = base_dir {
-            if let Some(gametdb) = GameTDB::load_from_base_dir(base_dir) {
-                if let Some(gametdb_title) = gametdb.get_title(&id, None) {
-                    gametdb_title
-                } else {
-                    GAME_TITLES.get(&id).copied().unwrap_or(&title).to_string()
-                }
-            } else {
-                GAME_TITLES.get(&id).copied().unwrap_or(&title).to_string()
-            }
+        let display_title = if let Some(base_dir) = base_dir
+            && let Some(gametdb) = GameTDB::load_from_base_dir(base_dir)
+            && let Some(gametdb_title) = gametdb.get_title(&id, None)
+        {
+            gametdb_title
         } else {
             GAME_TITLES.get(&id).copied().unwrap_or(&title).to_string()
         };

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,41 +3,12 @@
 
 use crate::SUPPORTED_INPUT_EXTENSIONS;
 use crate::titles::GAME_TITLES;
-use crate::util::{gametdb::GameTDB, redump};
+use crate::util::{gametdb::GameTDB, redump, regions::REGION_TO_LANG};
 use anyhow::{Context, Result, bail};
 use filetime::FileTime;
 use nod::read::{DiscMeta, DiscOptions, DiscReader};
-use phf::phf_map;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
-
-// A static map to convert the region character from a game's ID to a language code
-// used by the GameTDB API for fetching cover art.
-static REGION_TO_LANG: phf::Map<char, &'static str> = phf_map! {
-    'A' => "EN", // System Wii Channels (i.e. Mii Channel)
-    'B' => "EN", // Ufouria: The Saga (NA)
-    'D' => "DE", // Germany
-    'E' => "US", // USA
-    'F' => "FR", // France
-    'H' => "NL", // Netherlands
-    'I' => "IT", // Italy
-    'J' => "JA", // Japan
-    'K' => "KO", // Korea
-    'L' => "EN", // Japanese import to Europe, Australia and other PAL regions
-    'M' => "EN", // American import to Europe, Australia and other PAL regions
-    'N' => "US", // Japanese import to USA and other NTSC regions
-    'P' => "EN", // Europe and other PAL regions such as Australia
-    'Q' => "KO", // Japanese Virtual Console import to Korea
-    'R' => "RU", // Russia
-    'S' => "ES", // Spain
-    'T' => "KO", // American Virtual Console import to Korea
-    'U' => "EN", // Australia / Europe alternate languages
-    'V' => "EN", // Scandinavia
-    'W' => "ZH", // Republic of China (Taiwan) / Hong Kong / Macau
-    'X' => "EN", // Europe alternate languages / US special releases
-    'Y' => "EN", // Europe alternate languages / US special releases
-    'Z' => "EN", // Europe alternate languages / US special releases
-};
 
 /// Represents the console type for a game
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/jobs/download_covers.rs
+++ b/src/jobs/download_covers.rs
@@ -1,0 +1,205 @@
+use super::{Job, JobContext, JobResult, JobState, start_job, update_status};
+use crate::cover_manager::CoverType;
+use crate::util::regions::REGION_TO_LANG;
+use anyhow::{Context, Result};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::Receiver;
+use std::task::Waker;
+use std::time::Duration;
+use tempfile::NamedTempFile;
+
+pub struct DownloadCoversConfig {
+    pub base_dir: PathBuf,
+    pub cover_type: CoverType,
+    pub game_ids: Vec<String>,
+}
+
+pub struct DownloadCoversResult {
+    pub downloaded: usize,
+    pub skipped: usize,
+    pub failed: usize,
+    pub failed_ids: Vec<String>,
+    pub cover_type: CoverType,
+}
+
+pub fn start_download_covers(waker: Waker, config: DownloadCoversConfig) -> JobState {
+    let title = format!(
+        "Download {} {} covers",
+        config.game_ids.len(),
+        match config.cover_type {
+            CoverType::Cover3D => "3D",
+            CoverType::Cover2D => "2D",
+            CoverType::CoverFull => "full",
+            CoverType::Disc => "disc",
+        }
+    );
+    start_job(
+        waker,
+        &title,
+        Job::DownloadCovers,
+        move |context, cancel| {
+            download_covers(context, cancel, config).map(JobResult::DownloadCovers)
+        },
+    )
+}
+
+fn download_covers(
+    context: JobContext,
+    cancel: Receiver<()>,
+    config: DownloadCoversConfig,
+) -> Result<Box<DownloadCoversResult>> {
+    let mut downloaded = 0;
+    let mut skipped = 0;
+    let mut failed = 0;
+    let mut failed_ids = Vec::new();
+
+    let total = config.game_ids.len() as u32;
+
+    for (idx, game_id) in config.game_ids.iter().enumerate() {
+        // Update status and check for cancellation
+        update_status(
+            &context,
+            format!("Downloading {} cover", game_id),
+            idx as u32,
+            total,
+            &cancel,
+        )?;
+
+        // Check if already exists
+        let cover_path = config
+            .base_dir
+            .join("apps/usbloader_gx")
+            .join(config.cover_type.subdirectory())
+            .join(format!("{}.png", game_id));
+
+        if cover_path.exists() {
+            skipped += 1;
+            continue;
+        }
+
+        // Download with retries
+        match download_with_retries(&config.base_dir, game_id, config.cover_type) {
+            Ok(_) => {
+                downloaded += 1;
+                log::info!(
+                    "Downloaded {} cover for {}",
+                    config.cover_type.name(),
+                    game_id
+                );
+            }
+            Err(e) if e.to_string().contains("404") || e.to_string().contains("Not Found") => {
+                failed += 1;
+                failed_ids.push(game_id.clone());
+                log::debug!("Cover not found for {}: {}", game_id, e);
+            }
+            Err(e) => {
+                failed += 1;
+                log::warn!("Failed to download {} cover: {}", game_id, e);
+            }
+        }
+    }
+
+    // Final status
+    update_status(
+        &context,
+        format!("Downloaded {} covers", downloaded),
+        total,
+        total,
+        &cancel,
+    )?;
+
+    Ok(Box::new(DownloadCoversResult {
+        downloaded,
+        skipped,
+        failed,
+        failed_ids,
+        cover_type: config.cover_type,
+    }))
+}
+
+fn download_with_retries(base_dir: &Path, game_id: &str, cover_type: CoverType) -> Result<()> {
+    let mut attempts = 0;
+    loop {
+        match download_single_cover(base_dir, game_id, cover_type) {
+            Ok(_) => return Ok(()),
+            Err(e) if e.to_string().contains("404") || e.to_string().contains("Not Found") => {
+                return Err(e); // Don't retry 404s
+            }
+            Err(e) if attempts < 3 => {
+                std::thread::sleep(Duration::from_secs(1 << attempts));
+                attempts += 1;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+fn download_single_cover(base_dir: &Path, game_id: &str, cover_type: CoverType) -> Result<()> {
+    // Determine language from game ID region
+    let region_char = game_id
+        .chars()
+        .nth(3)
+        .context("Game ID too short to determine region")?;
+    let language = REGION_TO_LANG.get(&region_char).unwrap_or(&"EN");
+
+    // Construct GameTDB API URL
+    let url = format!(
+        "https://art.gametdb.com/wii/{}/{}/{}.png",
+        cover_type.api_endpoint(),
+        language,
+        game_id
+    );
+
+    // Download the cover to a temporary file
+    log::debug!("Downloading cover from: {}", url);
+    let response = reqwest::blocking::get(&url).context("Failed to send HTTP request")?;
+
+    if !response.status().is_success() {
+        if response.status() == 404 {
+            anyhow::bail!("404 Not Found");
+        } else {
+            anyhow::bail!("HTTP error: {}", response.status());
+        }
+    }
+
+    let bytes = response.bytes().context("Failed to read response body")?;
+
+    // Write to temporary file first
+    let mut temp_file =
+        NamedTempFile::new().context("Failed to create temporary file for cover")?;
+    temp_file
+        .write_all(&bytes)
+        .context("Failed to write cover to temporary file")?;
+    temp_file
+        .flush()
+        .context("Failed to flush temporary file")?;
+
+    // Create target directory structure
+    let target_path = base_dir
+        .join("apps/usbloader_gx")
+        .join(cover_type.subdirectory())
+        .join(format!("{}.png", game_id));
+
+    if let Some(parent) = target_path.parent() {
+        fs::create_dir_all(parent).context("Failed to create cover directory")?;
+    }
+
+    // Copy to final location (safer than persist for cross-filesystem)
+    fs::copy(temp_file.path(), &target_path).context("Failed to copy cover to final location")?;
+    // temp_file will be automatically cleaned up when dropped
+
+    Ok(())
+}
+
+impl CoverType {
+    pub fn name(&self) -> &'static str {
+        match self {
+            CoverType::Cover3D => "3D",
+            CoverType::Cover2D => "2D",
+            CoverType::CoverFull => "full",
+            CoverType::Disc => "disc",
+        }
+    }
+}

--- a/src/jobs/download_covers.rs
+++ b/src/jobs/download_covers.rs
@@ -1,7 +1,7 @@
 use super::{Job, JobContext, JobResult, JobState, start_job, update_status};
 use crate::cover_manager::CoverType;
 use crate::util::regions::REGION_TO_LANG;
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use log::{debug, info, warn};
 use std::fs;
 use std::io::Write;
@@ -61,7 +61,7 @@ fn download_covers(
         // Update status and check for cancellation
         update_status(
             &context,
-            format!("Downloading {} cover", game_id),
+            format!("Downloading cover for {}", game_id),
             idx as u32,
             total,
             &cancel,
@@ -161,9 +161,9 @@ fn download_single_cover(base_dir: &Path, game_id: &str, cover_type: CoverType) 
 
     if !response.status().is_success() {
         if response.status() == 404 {
-            anyhow::bail!("404 Not Found");
+            bail!("404 Not Found");
         } else {
-            anyhow::bail!("HTTP error: {}", response.status());
+            bail!("HTTP error: {}", response.status());
         }
     }
 

--- a/src/jobs/download_covers.rs
+++ b/src/jobs/download_covers.rs
@@ -127,7 +127,7 @@ fn download_with_retries(base_dir: &Path, game_id: &str, cover_type: CoverType) 
             Err(e) if e.to_string().contains("404") || e.to_string().contains("Not Found") => {
                 return Err(e); // Don't retry 404s
             }
-            Err(e) if attempts < 3 => {
+            Err(_e) if attempts < 3 => {
                 std::thread::sleep(Duration::from_secs(1 << attempts));
                 attempts += 1;
             }

--- a/src/jobs/download_database.rs
+++ b/src/jobs/download_database.rs
@@ -47,7 +47,7 @@ fn download_database(
         Ok(path) => {
             update_status(
                 &context,
-                "GameTDB database downloaded successfully".to_string(),
+                "GameTDB database updated successfully".to_string(),
                 2,
                 2,
                 &cancel,

--- a/src/jobs/download_database.rs
+++ b/src/jobs/download_database.rs
@@ -1,0 +1,112 @@
+use super::{Job, JobContext, JobResult, JobState, start_job, update_status};
+use anyhow::{Context, Result};
+use std::fs::{self, File};
+use std::io::{BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::Receiver;
+use std::task::Waker;
+use tempfile::NamedTempFile;
+
+pub struct DownloadDatabaseConfig {
+    pub base_dir: PathBuf,
+}
+
+pub struct DownloadDatabaseResult {
+    pub success: bool,
+    pub path: Option<PathBuf>,
+}
+
+pub fn start_download_database(waker: Waker, config: DownloadDatabaseConfig) -> JobState {
+    start_job(
+        waker,
+        "Download GameTDB Database",
+        Job::DownloadDatabase,
+        move |context, cancel| {
+            download_database(context, cancel, config).map(JobResult::DownloadDatabase)
+        },
+    )
+}
+
+fn download_database(
+    context: JobContext,
+    cancel: Receiver<()>,
+    config: DownloadDatabaseConfig,
+) -> Result<Box<DownloadDatabaseResult>> {
+    // Update status
+    update_status(
+        &context,
+        "Downloading wiitdb.zip".to_string(),
+        0,
+        2,
+        &cancel,
+    )?;
+
+    // Download logic
+    match download_database_blocking(&config.base_dir) {
+        Ok(path) => {
+            update_status(&context, "Complete".to_string(), 2, 2, &cancel)?;
+            Ok(Box::new(DownloadDatabaseResult {
+                success: true,
+                path: Some(path),
+            }))
+        }
+        Err(e) => {
+            log::error!("Failed to download GameTDB database: {}", e);
+            Err(e)
+        }
+    }
+}
+
+fn download_database_blocking(base_dir: &Path) -> Result<PathBuf> {
+    log::info!("Downloading GameTDB database from https://www.gametdb.com/wiitdb.zip");
+
+    // Download the zip file to a temporary file
+    let mut temp_zip = NamedTempFile::new().context("Failed to create temporary file for zip")?;
+
+    let response = reqwest::blocking::get("https://www.gametdb.com/wiitdb.zip")
+        .context("Failed to download wiitdb.zip")?;
+
+    if !response.status().is_success() {
+        anyhow::bail!("HTTP error downloading wiitdb.zip: {}", response.status());
+    }
+
+    let bytes = response
+        .bytes()
+        .context("Failed to read wiitdb.zip response")?;
+
+    temp_zip
+        .write_all(&bytes)
+        .context("Failed to write temporary zip file")?;
+    temp_zip
+        .flush()
+        .context("Failed to flush temporary zip file")?;
+
+    // Create target directory
+    let target_dir = base_dir.join("apps/usbloader_gx");
+    fs::create_dir_all(&target_dir).context("Failed to create usbloader_gx directory")?;
+
+    // Extract the zip file
+    let file = File::open(temp_zip.path()).context("Failed to open temporary zip file")?;
+    let mut archive =
+        zip::ZipArchive::new(BufReader::new(file)).context("Failed to read zip archive")?;
+
+    // Look for wiitdb.xml in the archive
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i).context("Failed to access zip entry")?;
+        let name = file.name();
+
+        // Only extract wiitdb.xml
+        if name == "wiitdb.xml" || name.ends_with("/wiitdb.xml") {
+            // Extract directly to the target location
+            let target_path = target_dir.join("wiitdb.xml");
+            let mut outfile = File::create(&target_path).context("Failed to create wiitdb.xml")?;
+            std::io::copy(&mut file, &mut outfile).context("Failed to extract wiitdb.xml")?;
+            outfile.flush().context("Failed to flush wiitdb.xml")?;
+
+            log::info!("Successfully installed wiitdb.xml to {:?}", target_path);
+            return Ok(target_path);
+        }
+    }
+
+    anyhow::bail!("wiitdb.xml not found in downloaded archive")
+}

--- a/src/jobs/egui_waker.rs
+++ b/src/jobs/egui_waker.rs
@@ -1,0 +1,15 @@
+use eframe::egui::Context;
+use std::sync::Arc;
+use std::task::{Wake, Waker};
+
+struct EguiWaker(Context);
+
+impl Wake for EguiWaker {
+    fn wake(self: Arc<Self>) {
+        self.0.request_repaint();
+    }
+}
+
+pub fn egui_waker(ctx: &Context) -> Waker {
+    Waker::from(Arc::new(EguiWaker(ctx.clone())))
+}

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,0 +1,258 @@
+use std::{
+    sync::{
+        Arc, RwLock,
+        atomic::{AtomicUsize, Ordering},
+        mpsc::{Receiver, Sender, TryRecvError},
+    },
+    task::Waker,
+    thread::JoinHandle,
+};
+
+use anyhow::Result;
+
+pub mod download_covers;
+pub mod download_database;
+pub mod egui_waker;
+
+use download_covers::DownloadCoversResult;
+use download_database::DownloadDatabaseResult;
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum Job {
+    DownloadCovers,
+    DownloadDatabase,
+}
+
+pub static JOB_ID: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Default)]
+pub struct JobQueue {
+    pub jobs: Vec<JobState>,
+    pub results: Vec<JobResult>,
+}
+
+impl JobQueue {
+    /// Adds a job to the queue.
+    #[inline]
+    pub fn push(&mut self, state: JobState) {
+        self.jobs.push(state);
+    }
+
+    /// Adds a job to the queue if a job of the given kind is not already running.
+    #[inline]
+    pub fn push_once(&mut self, job: Job, func: impl FnOnce() -> JobState) {
+        if !self.is_running(job) {
+            self.push(func());
+        }
+    }
+
+    /// Returns whether a job of the given kind is running.
+    pub fn is_running(&self, kind: Job) -> bool {
+        self.jobs
+            .iter()
+            .any(|j| j.kind == kind && j.handle.is_some())
+    }
+
+    /// Returns whether any job is running.
+    pub fn any_running(&self) -> bool {
+        self.jobs.iter().any(|job| {
+            if let Some(handle) = &job.handle {
+                return !handle.is_finished();
+            }
+            false
+        })
+    }
+
+    /// Returns the number of active jobs.
+    pub fn active_count(&self) -> usize {
+        self.jobs
+            .iter()
+            .filter(|j| j.handle.as_ref().map_or(false, |h| !h.is_finished()))
+            .count()
+    }
+
+    /// Iterates over all jobs mutably.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut JobState> + '_ {
+        self.jobs.iter_mut()
+    }
+
+    /// Iterates over all finished jobs, returning the job state and the result.
+    pub fn iter_finished(
+        &mut self,
+    ) -> impl Iterator<Item = (&mut JobState, std::thread::Result<JobResult>)> + '_ {
+        self.jobs.iter_mut().filter_map(|job| {
+            if let Some(handle) = &job.handle {
+                if !handle.is_finished() {
+                    return None;
+                }
+                let result = job.handle.take().unwrap().join();
+                return Some((job, result));
+            }
+            None
+        })
+    }
+
+    /// Clears all finished jobs.
+    pub fn clear_finished(&mut self) {
+        self.jobs.retain(|job| {
+            !(job.handle.is_none() && job.context.status.read().unwrap().error.is_none())
+        });
+    }
+
+    /// Clears all errored jobs.
+    pub fn clear_errored(&mut self) {
+        self.jobs
+            .retain(|job| job.context.status.read().unwrap().error.is_none());
+    }
+
+    /// Removes a job from the queue given its ID.
+    pub fn remove(&mut self, id: usize) {
+        self.jobs.retain(|job| job.id != id);
+    }
+
+    /// Collects the results of all finished jobs and handles any errors.
+    pub fn collect_results(&mut self) {
+        let mut results = vec![];
+        for (job, result) in self.iter_finished() {
+            match result {
+                Ok(result) => {
+                    match result {
+                        JobResult::None => {
+                            // Job context contains the error
+                        }
+                        _ => results.push(result),
+                    }
+                }
+                Err(err) => {
+                    let err = if let Some(msg) = err.downcast_ref::<&'static str>() {
+                        anyhow::Error::msg(*msg)
+                    } else if let Some(msg) = err.downcast_ref::<String>() {
+                        anyhow::Error::msg(msg.clone())
+                    } else {
+                        anyhow::Error::msg("Thread panicked")
+                    };
+                    let result = job.context.status.write();
+                    if let Ok(mut guard) = result {
+                        guard.error = Some(err);
+                    } else {
+                        drop(result);
+                        job.context.status = Arc::new(RwLock::new(JobStatus {
+                            title: "Error".to_string(),
+                            progress_percent: 0.0,
+                            progress_items: None,
+                            status: String::new(),
+                            error: Some(err),
+                        }));
+                    }
+                }
+            }
+        }
+        self.results.append(&mut results);
+        self.clear_finished();
+    }
+}
+
+#[derive(Clone)]
+pub struct JobContext {
+    pub status: Arc<RwLock<JobStatus>>,
+    pub waker: Waker,
+}
+
+pub struct JobState {
+    pub id: usize,
+    pub kind: Job,
+    pub handle: Option<JoinHandle<JobResult>>,
+    pub context: JobContext,
+    pub cancel: Sender<()>,
+}
+
+#[derive(Default)]
+pub struct JobStatus {
+    pub title: String,
+    pub progress_percent: f32,
+    pub progress_items: Option<[u32; 2]>,
+    pub status: String,
+    pub error: Option<anyhow::Error>,
+}
+
+pub enum JobResult {
+    None,
+    DownloadCovers(Box<DownloadCoversResult>),
+    DownloadDatabase(Box<DownloadDatabaseResult>),
+}
+
+pub fn start_job(
+    waker: Waker,
+    title: &str,
+    kind: Job,
+    run: impl FnOnce(JobContext, Receiver<()>) -> Result<JobResult> + Send + 'static,
+) -> JobState {
+    let status = Arc::new(RwLock::new(JobStatus {
+        title: title.to_string(),
+        progress_percent: 0.0,
+        progress_items: None,
+        status: String::new(),
+        error: None,
+    }));
+    let context = JobContext {
+        status: status.clone(),
+        waker: waker.clone(),
+    };
+    let context_inner = JobContext {
+        status: status.clone(),
+        waker,
+    };
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || match run(context_inner, rx) {
+        Ok(state) => state,
+        Err(e) => {
+            if let Ok(mut w) = status.write() {
+                w.error = Some(e);
+            }
+            JobResult::None
+        }
+    });
+    let id = JOB_ID.fetch_add(1, Ordering::Relaxed);
+    JobState {
+        id,
+        kind,
+        handle: Some(handle),
+        context,
+        cancel: tx,
+    }
+}
+
+pub fn update_status(
+    context: &JobContext,
+    status: String,
+    current: u32,
+    total: u32,
+    cancel: &Receiver<()>,
+) -> Result<()> {
+    let mut w = context
+        .status
+        .write()
+        .map_err(|_| anyhow::Error::msg("Failed to lock job status"))?;
+    w.progress_items = Some([current, total]);
+    w.progress_percent = if total > 0 {
+        current as f32 / total as f32
+    } else {
+        0.0
+    };
+    if should_cancel(cancel) {
+        w.status = "Cancelled".to_string();
+        return Err(anyhow::Error::msg("Cancelled"));
+    } else {
+        w.status = status;
+    }
+    drop(w);
+    context.waker.wake_by_ref();
+    Ok(())
+}
+
+pub fn should_cancel(rx: &Receiver<()>) -> bool {
+    match rx.try_recv() {
+        Ok(_) | Err(TryRecvError::Disconnected) => true,
+        Err(_) => false,
+    }
+}

--- a/src/jobs/verify.rs
+++ b/src/jobs/verify.rs
@@ -1,0 +1,190 @@
+use super::{
+    Job, JobContext, JobResult, JobState, should_cancel, start_job, update_status_with_bytes,
+};
+use crate::game::{CalculatedHashes, Game, VerificationStatus};
+use anyhow::Result;
+use nod::read::{DiscOptions, DiscReader, PartitionEncryption};
+use nod::write::{DiscWriter, FormatOptions, ProcessOptions};
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::Receiver;
+use std::task::Waker;
+
+pub struct VerifyConfig {
+    pub games: Vec<Box<Game>>,
+}
+
+pub struct VerifyResult {
+    pub verified: usize,
+    pub passed: usize,
+    pub failed: usize,
+}
+
+pub fn start_verify(waker: Waker, config: VerifyConfig) -> JobState {
+    let title = format!(
+        "Verify {} game{}",
+        config.games.len(),
+        if config.games.len() == 1 { "" } else { "s" }
+    );
+
+    start_job(waker, &title, Job::Verify, move |context, cancel| {
+        verify_games(context, cancel, config).map(JobResult::Verify)
+    })
+}
+
+fn verify_games(
+    context: JobContext,
+    cancel: Receiver<()>,
+    config: VerifyConfig,
+) -> Result<Box<VerifyResult>> {
+    let mut verified = 0;
+    let mut passed = 0;
+    let mut failed = 0;
+
+    let total = config.games.len() as u32;
+    let cancelled = Arc::new(AtomicBool::new(false));
+
+    for (idx, game) in config.games.into_iter().enumerate() {
+        // Check for cancellation
+        if should_cancel(&cancel) {
+            cancelled.store(true, Ordering::Relaxed);
+            break;
+        }
+
+        let game_name = game.title.clone();
+
+        // Perform the verification
+        match verify_game(
+            &game,
+            idx as u32,
+            total,
+            game_name.clone(),
+            &context,
+            &cancel,
+            Arc::clone(&cancelled),
+        ) {
+            Ok(status) => {
+                verified += 1;
+                match status {
+                    VerificationStatus::FullyVerified(_, _)
+                    | VerificationStatus::EmbeddedMatch(_) => {
+                        passed += 1;
+                        log::info!("{} verification: PASSED", game_name);
+                    }
+                    VerificationStatus::Failed(_, _) => {
+                        failed += 1;
+                        log::warn!("{} verification: FAILED", game_name);
+                    }
+                    VerificationStatus::NotVerified => {
+                        log::info!("{} verification: NOT VERIFIED", game_name);
+                    }
+                }
+            }
+            Err(e) => {
+                // Check if it was cancelled
+                if e.to_string().contains("Cancelled") {
+                    cancelled.store(true, Ordering::Relaxed);
+                    break;
+                }
+                failed += 1;
+                log::warn!("Failed to verify {}: {}", game_name, e);
+            }
+        }
+    }
+
+    // Final status
+    let final_status = if cancelled.load(Ordering::Relaxed) {
+        format!(
+            "Verification cancelled ({} completed, {} passed, {} failed)",
+            verified, passed, failed
+        )
+    } else {
+        format!(
+            "Verified {} game{} ({} passed, {} failed)",
+            verified,
+            if verified == 1 { "" } else { "s" },
+            passed,
+            failed
+        )
+    };
+
+    let _ = update_status_with_bytes(&context, final_status, total, total, 1, 1, None, &cancel);
+
+    Ok(Box::new(VerifyResult {
+        verified,
+        passed,
+        failed,
+    }))
+}
+
+/// Verify a single game's integrity by processing the entire disc
+fn verify_game(
+    game: &Game,
+    current_idx: u32,
+    total_items: u32,
+    game_name: String,
+    context: &JobContext,
+    cancel: &Receiver<()>,
+    cancelled: Arc<AtomicBool>,
+) -> Result<VerificationStatus> {
+    let disc_path = game
+        .get_disc_file_path()
+        .ok_or_else(|| anyhow::anyhow!("No disc image found"))?;
+
+    // Open the disc
+    let disc = DiscReader::new(
+        &disc_path,
+        &DiscOptions {
+            partition_encryption: PartitionEncryption::Original,
+            preloader_threads: 1,
+        },
+    )?;
+    let disc_writer = DiscWriter::new(disc, &FormatOptions::default())?;
+    let total = disc_writer.progress_bound();
+
+    // Process the disc to calculate hashes
+    let finalization = disc_writer.process(
+        |_data, pos, _| {
+            // Check for cancellation
+            if cancelled.load(Ordering::Relaxed) {
+                return Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "Operation cancelled by user",
+                ));
+            }
+
+            // Send progress updates
+            update_status_with_bytes(
+                context,
+                format!("Verifying {}", game_name),
+                current_idx,
+                total_items,
+                pos,
+                total,
+                Some(game_name.clone()),
+                cancel,
+            )
+            .map_err(|_| io::Error::new(io::ErrorKind::Interrupted, "Cancelled"))?;
+
+            Ok(())
+        },
+        &ProcessOptions {
+            processor_threads: 0,
+            digest_crc32: true,
+            digest_md5: false, // MD5 is slow, skip it
+            digest_sha1: true,
+            digest_xxh64: true,
+        },
+    )?;
+
+    // Store calculated hashes
+    let calculated = CalculatedHashes {
+        crc32: finalization.crc32,
+        sha1: finalization.sha1,
+        xxh64: finalization.xxh64,
+    };
+
+    // Check against Redump database using the shared logic
+    Ok(calculated.into_verification_status())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod app;
 mod base_dir;
 mod components;
 mod convert;
+mod cover_manager;
 mod game;
 mod messages;
 mod titles;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod components;
 mod convert;
 mod cover_manager;
 mod game;
+mod jobs;
 mod messages;
 mod titles;
 mod update_check;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod game;
 mod jobs;
 mod messages;
 mod titles;
+mod toasts;
 mod update_check;
 mod util;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ pub const PRODUCT_NAME: &str = "TinyWiiBackupManager";
 pub mod app;
 mod base_dir;
 mod components;
-mod convert;
 mod cover_manager;
 mod game;
 mod jobs;

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,5 +1,4 @@
 use crate::app::{App, OperationResult, OperationState, OperationType};
-use crate::cover_manager::CoverType;
 use crate::game::{Game, VerificationStatus};
 use crate::update_check::UpdateInfo;
 use anyhow::Error;
@@ -30,18 +29,6 @@ pub enum BackgroundMessage {
     StartSingleVerification(Box<Game>),
     /// Signal to cancel ongoing operation
     CancelOperation,
-    /// Signal that a cover has been downloaded
-    CoverDownloaded {
-        game_id: String,
-        cover_type: CoverType,
-        path: PathBuf,
-    },
-    /// Signal that a cover download failed
-    CoverDownloadFailed {
-        game_id: String,
-        cover_type: CoverType,
-        error: String,
-    },
 }
 
 /// Processes messages received from background tasks
@@ -261,29 +248,6 @@ pub fn handle_messages(app: &mut App, ctx: &egui::Context) {
                 // Set cancellation flag - the thread will detect this and exit
                 app.operation_cancelled.store(true, Ordering::Relaxed);
                 // The actual "cancelled" message will be shown when the thread reports completion
-            }
-
-            BackgroundMessage::CoverDownloaded {
-                game_id,
-                cover_type,
-                path: _,
-            } => {
-                // Cover downloaded successfully - UI will automatically refresh and show the cover
-                log::debug!("Cover downloaded for {} ({:?})", game_id, cover_type);
-            }
-
-            BackgroundMessage::CoverDownloadFailed {
-                game_id,
-                cover_type,
-                error,
-            } => {
-                // Cover download failed - log the error but don't show toast (too noisy)
-                log::debug!(
-                    "Cover download failed for {} ({:?}): {}",
-                    game_id,
-                    cover_type,
-                    error
-                );
             }
         }
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -29,8 +29,6 @@ pub enum BackgroundMessage {
     StartSingleVerification(Box<Game>),
     /// Signal to cancel ongoing operation
     CancelOperation,
-    /// Signal that GameTDB database download completed
-    GameTDBDownloadComplete,
 }
 
 /// Processes messages received from background tasks
@@ -250,19 +248,6 @@ pub fn handle_messages(app: &mut App, ctx: &egui::Context) {
                 // Set cancellation flag - the thread will detect this and exit
                 app.operation_cancelled.store(true, Ordering::Relaxed);
                 // The actual "cancelled" message will be shown when the thread reports completion
-            }
-
-            BackgroundMessage::GameTDBDownloadComplete => {
-                // Clear the cached GameTDB instance to force reload
-                crate::util::gametdb::clear_cache();
-
-                // Refresh games to reload titles from the new database
-                if let Err(e) = app.refresh_games() {
-                    let _ = sender.send(BackgroundMessage::Error(e));
-                } else {
-                    app.top_left_toasts
-                        .success("GameTDB database downloaded successfully!");
-                }
             }
         }
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -263,14 +263,27 @@ pub fn handle_messages(app: &mut App, ctx: &egui::Context) {
                 // The actual "cancelled" message will be shown when the thread reports completion
             }
 
-            BackgroundMessage::CoverDownloaded { game_id, cover_type, path: _ } => {
+            BackgroundMessage::CoverDownloaded {
+                game_id,
+                cover_type,
+                path: _,
+            } => {
                 // Cover downloaded successfully - UI will automatically refresh and show the cover
                 log::debug!("Cover downloaded for {} ({:?})", game_id, cover_type);
             }
 
-            BackgroundMessage::CoverDownloadFailed { game_id, cover_type, error } => {
+            BackgroundMessage::CoverDownloadFailed {
+                game_id,
+                cover_type,
+                error,
+            } => {
                 // Cover download failed - log the error but don't show toast (too noisy)
-                log::debug!("Cover download failed for {} ({:?}): {}", game_id, cover_type, error);
+                log::debug!(
+                    "Cover download failed for {} ({:?}): {}",
+                    game_id,
+                    cover_type,
+                    error
+                );
             }
         }
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,24 +1,15 @@
-use crate::app::{App, OperationResult, OperationState, OperationType};
-use crate::game::{Game, VerificationStatus};
+use crate::app::App;
+use crate::game::Game;
 use crate::update_check::UpdateInfo;
 use anyhow::Error;
 use eframe::egui;
 use log::error;
-use std::io;
-use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 
 /// Messages that can be sent from background tasks to the main thread
 #[derive(Debug)]
 pub enum BackgroundMessage {
-    /// Signal that we're starting to process an item (with name for display)
-    OperationStartItem(usize, String),
-    /// Signal for current operation progress (used for both conversion and verification)
+    /// Signal for current operation progress (kept for compatibility with convert/verify functions)
     OperationProgress(u64, u64),
-    /// Signal that an operation has completed for one item
-    OperationItemComplete(PathBuf, OperationResult),
-    /// Signal that the entire operation has completed
-    OperationComplete,
     /// Signal that the directory has changed
     DirectoryChanged,
     /// Signal that an error occurred
@@ -27,8 +18,6 @@ pub enum BackgroundMessage {
     UpdateCheckComplete(Option<UpdateInfo>),
     /// Signal to start verification of a single game
     StartSingleVerification(Box<Game>),
-    /// Signal to cancel ongoing operation
-    CancelOperation,
 }
 
 /// Processes messages received from background tasks
@@ -37,181 +26,9 @@ pub fn handle_messages(app: &mut App, ctx: &egui::Context) {
 
     for msg in app.inbox.read(ctx) {
         match msg {
-            BackgroundMessage::OperationProgress(progress, total) => {
-                if let OperationState::InProgress {
-                    operation,
-                    total_items,
-                    items_completed,
-                    current_item,
-                    items_passed,
-                    items_failed,
-                    ..
-                } = app.operation_state.clone()
-                {
-                    app.operation_state = OperationState::InProgress {
-                        operation,
-                        total_items,
-                        items_completed,
-                        current_item,
-                        current_progress: (progress, total),
-                        items_passed,
-                        items_failed,
-                    };
-                }
-            }
-
-            BackgroundMessage::OperationStartItem(i, name) => {
-                if let OperationState::InProgress {
-                    operation,
-                    total_items,
-                    items_passed,
-                    items_failed,
-                    ..
-                } = app.operation_state.clone()
-                {
-                    app.operation_state = OperationState::InProgress {
-                        operation,
-                        total_items,
-                        items_completed: i,
-                        current_item: name,
-                        current_progress: (0, 0),
-                        items_passed,
-                        items_failed,
-                    };
-                }
-            }
-
-            BackgroundMessage::OperationItemComplete(game_dir, result) => {
-                let item_passed = match result {
-                    OperationResult::ConversionComplete(calculated_hashes) => {
-                        // Find the newly created game and update its verification status
-                        if let Err(e) = app.refresh_games() {
-                            let _ = sender.send(BackgroundMessage::Error(e));
-                        }
-                        if let Some(game) = app.games.iter_mut().find(|g| g.path == game_dir) {
-                            game.set_verification_status(
-                                calculated_hashes.into_verification_status(),
-                            );
-                            true
-                        } else {
-                            false
-                        }
-                    }
-                    OperationResult::VerificationComplete(verification_status) => {
-                        // Track whether this game passed or failed
-                        let game_passed = matches!(
-                            verification_status,
-                            VerificationStatus::FullyVerified(_, _)
-                                | VerificationStatus::EmbeddedMatch(_)
-                        );
-                        if let Some(game) = app.games.iter_mut().find(|g| g.path == game_dir) {
-                            game.set_verification_status(verification_status);
-                        }
-                        game_passed
-                    }
-                    OperationResult::Error(e) => {
-                        // Check if this was a cancellation
-                        if let Some(nod::Error::Io(_, io_err)) = e.downcast_ref::<nod::Error>()
-                            && io_err.kind() == io::ErrorKind::Interrupted
-                        {
-                            // Cancelled - continue processing messages, wait for OperationComplete
-                            continue;
-                        } else {
-                            let _ = sender.send(BackgroundMessage::Error(e));
-                            false
-                        }
-                    }
-                };
-
-                if let OperationState::InProgress {
-                    operation,
-                    total_items,
-                    items_completed,
-                    items_passed,
-                    items_failed,
-                    current_item,
-                    current_progress,
-                    ..
-                } = app.operation_state.clone()
-                {
-                    app.operation_state = OperationState::InProgress {
-                        operation,
-                        total_items,
-                        items_completed,
-                        current_item,
-                        current_progress,
-                        items_passed: if item_passed {
-                            items_passed + 1
-                        } else {
-                            items_passed
-                        },
-                        items_failed: if item_passed {
-                            items_failed
-                        } else {
-                            items_failed + 1
-                        },
-                    };
-                }
-            }
-
-            BackgroundMessage::OperationComplete => {
-                // Check if this was due to cancellation
-                let was_cancelled = app.operation_cancelled.load(Ordering::Relaxed);
-
-                // Get operation type and stats before resetting state
-                let (operation_type, total_items, items_passed, items_failed) =
-                    if let OperationState::InProgress {
-                        operation,
-                        total_items,
-                        items_passed,
-                        items_failed,
-                        ..
-                    } = app.operation_state
-                    {
-                        (Some(operation), total_items, items_passed, items_failed)
-                    } else {
-                        (None, 0, 0, 0)
-                    };
-
-                app.operation_state = OperationState::Idle;
-
-                if was_cancelled {
-                    app.bottom_right_toasts.warning(match operation_type {
-                        Some(OperationType::Converting) => "Conversion cancelled",
-                        Some(OperationType::Verifying) => "Verification cancelled",
-                        None => "Operation cancelled",
-                    });
-                    // Reset the flag for next operation
-                    app.operation_cancelled.store(false, Ordering::Relaxed);
-                } else if let Some(operation_type) = operation_type {
-                    // Show completion message based on operation type
-                    match operation_type {
-                        OperationType::Converting => {
-                            app.bottom_right_toasts.success(format!(
-                                "Conversion complete! {} file{} converted",
-                                total_items,
-                                if total_items == 1 { "" } else { "s" }
-                            ));
-                        }
-                        OperationType::Verifying => {
-                            if items_failed > 0 {
-                                app.bottom_right_toasts.warning(format!(
-                                    "Verification complete: {} game{} passed, {} game{} failed",
-                                    items_passed,
-                                    if items_passed == 1 { "" } else { "s" },
-                                    items_failed,
-                                    if items_failed == 1 { "" } else { "s" }
-                                ));
-                            } else {
-                                app.bottom_right_toasts.success(format!(
-                                    "Verification complete! {} game{} verified",
-                                    total_items,
-                                    if total_items == 1 { "" } else { "s" }
-                                ));
-                            }
-                        }
-                    }
-                }
+            BackgroundMessage::OperationProgress(_progress, _total) => {
+                // This message is kept for compatibility but no longer processed here
+                // The job system handles progress directly
             }
 
             BackgroundMessage::DirectoryChanged => {
@@ -242,12 +59,6 @@ pub fn handle_messages(app: &mut App, ctx: &egui::Context) {
             BackgroundMessage::StartSingleVerification(game) => {
                 // Start verification of a single game
                 app.spawn_verification(vec![game]);
-            }
-
-            BackgroundMessage::CancelOperation => {
-                // Set cancellation flag - the thread will detect this and exit
-                app.operation_cancelled.store(true, Ordering::Relaxed);
-                // The actual "cancelled" message will be shown when the thread reports completion
             }
         }
     }

--- a/src/toasts.rs
+++ b/src/toasts.rs
@@ -1,0 +1,38 @@
+use eframe::egui;
+
+/// Helper function to create a styled `Toasts` instance for a specific screen corner.
+pub fn create_toasts(anchor: egui_notify::Anchor) -> egui_notify::Toasts {
+    egui_notify::Toasts::default()
+        .with_anchor(anchor)
+        .with_margin(egui::vec2(10.0, 32.0))
+        .with_shadow(egui::Shadow {
+            offset: [0, 0],
+            blur: 0,
+            spread: 1,
+            color: egui::Color32::GRAY,
+        })
+}
+
+/// Formats an `anyhow::Error` in multi-line format without backtrace.
+pub fn format_error(e: &anyhow::Error) -> String {
+    let mut msg = e.to_string();
+    let mut source = e.source();
+    while let Some(e) = source {
+        msg.push_str(&format!("\n  Caused by: {e}"));
+        source = e.source();
+    }
+    msg
+}
+
+/// Creates an error toast with the given message prefix and error details.
+pub fn error_toast(prefix: &str, e: &anyhow::Error) -> egui_notify::Toast {
+    let message = if prefix.is_empty() {
+        format_error(e)
+    } else {
+        format!("{}: {}", prefix, format_error(e))
+    };
+    let mut toast = egui_notify::Toast::error(message);
+    toast.duration(Some(std::time::Duration::from_secs(10)));
+    toast.closable(true);
+    toast
+}

--- a/src/util/gametdb.rs
+++ b/src/util/gametdb.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use log::{debug, error, info};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs::File;
@@ -84,12 +85,12 @@ pub struct GameTDB {
 pub fn clear_cache() {
     let mut cache = GAMETDB_INSTANCE.lock().unwrap();
     *cache = CacheState::NotLoaded;
-    log::info!("GameTDB cache cleared");
+    info!("GameTDB cache cleared");
 }
 
 impl GameTDB {
     pub fn load(path: &Path) -> Result<Self> {
-        log::info!("Loading GameTDB from: {:?}", path);
+        info!("Loading GameTDB from: {:?}", path);
 
         let file = BufReader::new(File::open(path)?);
         let db: WiiTDBFile = quick_xml::de::from_reader(file)?;
@@ -109,7 +110,7 @@ impl GameTDB {
             }
         }
 
-        log::info!("Loaded {} unique game IDs from GameTDB", games.len());
+        info!("Loaded {} unique game IDs from GameTDB", games.len());
         Ok(Self { games })
     }
 
@@ -131,19 +132,19 @@ impl GameTDB {
                 if wiitdb_path.exists() {
                     match Self::load(&wiitdb_path) {
                         Ok(db) => {
-                            log::info!("GameTDB loaded successfully from {:?}", wiitdb_path);
+                            info!("GameTDB loaded successfully from {:?}", wiitdb_path);
                             let arc_db = Arc::new(db);
                             *cache = CacheState::Loaded(Arc::clone(&arc_db));
                             Some(arc_db)
                         }
                         Err(e) => {
-                            log::error!("Failed to load GameTDB: {}", e);
+                            error!("Failed to load GameTDB: {}", e);
                             *cache = CacheState::Failed;
                             None
                         }
                     }
                 } else {
-                    log::debug!("GameTDB not found at {:?}", wiitdb_path);
+                    debug!("GameTDB not found at {:?}", wiitdb_path);
                     *cache = CacheState::Failed;
                     None
                 }
@@ -273,15 +274,10 @@ impl GameTDB {
             .filter(|g| g.id.len() == 6) // Count only full IDs
             .count()
     }
-
-    #[allow(dead_code)] // May be useful for testing or future hot-reload features
-    pub fn clear_cache() {
-        // This would only be used in tests or when reloading
-        // Since we use OnceLock, we can't actually clear it in production
-        // But this is here for API completeness
-    }
 }
 
+// All tests require a wiitdb.xml file in the project root (https://www.gametdb.com/wiitdb.zip)
+// The file is very large and not included in the repository, so these tests are ignored by default.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -292,6 +288,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_load_wiitdb() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -308,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_get_game_by_id() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -327,6 +325,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_get_game_with_partial_id() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -346,6 +345,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_get_title() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -372,6 +372,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_get_synopsis() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -390,6 +391,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_game_metadata() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -414,6 +416,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_multiple_locales() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -434,6 +437,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_rating_info() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -452,6 +456,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_nonexistent_game() {
         let path = get_test_wiitdb_path();
         if !path.exists() {
@@ -472,6 +477,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_additional_metadata() {
         let path = get_test_wiitdb_path();
         if !path.exists() {

--- a/src/util/gametdb.rs
+++ b/src/util/gametdb.rs
@@ -88,17 +88,12 @@ impl GameTDB {
         for game in db.games {
             let id = game.id.clone();
 
-            // Insert with full ID
+            // Insert with full ID (either 4 or 6 characters)
             games.insert(id.clone(), game.clone());
 
-            // Also insert with 6-char ID for compatibility
-            if id.len() >= 6 {
-                let id6 = id[..6].to_string();
-                games.entry(id6).or_insert_with(|| game.clone());
-            }
-
-            // Also insert with 4-char ID for compatibility
-            if id.len() >= 4 {
+            // For 6-char IDs, also index by first 4 characters for compatibility
+            // This allows looking up games by their 4-char disc ID
+            if id.len() == 6 {
                 let id4 = id[..4].to_string();
                 games.entry(id4).or_insert(game);
             }
@@ -146,13 +141,13 @@ impl GameTDB {
     }
 
     pub fn get_game(&self, id: &str) -> Option<&GameEntry> {
-        // Try full ID first
+        // Try exact match first
         self.games.get(id).or_else(|| {
-            // Try first 6 characters
-            if id.len() >= 6 {
+            // If ID is longer than 6, try first 6 characters
+            if id.len() > 6 {
                 self.games.get(&id[..6])
-            } else if id.len() >= 4 {
-                // Try first 4 characters
+            } else if id.len() > 4 {
+                // If ID is 5 characters, try first 4
                 self.games.get(&id[..4])
             } else {
                 None

--- a/src/util/gametdb.rs
+++ b/src/util/gametdb.rs
@@ -1,0 +1,474 @@
+use anyhow::Result;
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::Path;
+use std::sync::OnceLock;
+
+static GAMETDB_INSTANCE: OnceLock<Option<GameTDB>> = OnceLock::new();
+
+#[derive(Debug, Deserialize)]
+struct WiiTDBFile {
+    #[serde(rename = "game")]
+    games: Vec<GameEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // These fields are accessed through getter methods and will be used in future phases
+pub struct GameEntry {
+    #[serde(rename = "@name")]
+    pub name: String,
+    pub id: String,
+    pub region: Option<String>,
+    pub languages: Option<String>,
+    pub developer: Option<String>,
+    pub publisher: Option<String>,
+    pub genre: Option<String>,
+    pub rating: Option<Rating>,
+    pub input: Option<Input>,
+    #[serde(rename = "wi-fi")]
+    pub wifi: Option<WiFi>,
+    #[serde(default, rename = "locale")]
+    pub locales: Vec<LocaleInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // Used through get_rating() method
+pub struct Rating {
+    #[serde(rename = "@type")]
+    pub rating_type: Option<String>,
+    #[serde(rename = "@value")]
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // Used through get_players() method
+pub struct Input {
+    #[serde(rename = "@players")]
+    pub players: Option<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // Will be used in future phases
+pub struct WiFi {
+    #[serde(rename = "@players")]
+    pub players: Option<u8>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)] // synopsis is used through get_synopsis() method
+pub struct LocaleInfo {
+    #[serde(rename = "@lang")]
+    pub lang: String,
+    pub title: String,
+    pub synopsis: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct GameTDB {
+    games: HashMap<String, GameEntry>,
+}
+
+impl GameTDB {
+    pub fn load(path: &Path) -> Result<Self> {
+        log::info!("Loading GameTDB from: {:?}", path);
+
+        let file = BufReader::new(File::open(path)?);
+        let db: WiiTDBFile = quick_xml::de::from_reader(file)?;
+
+        let mut games = HashMap::new();
+        for game in db.games {
+            let id = game.id.clone();
+
+            // Insert with full ID
+            games.insert(id.clone(), game.clone());
+
+            // Also insert with 6-char ID for compatibility
+            if id.len() >= 6 {
+                let id6 = id[..6].to_string();
+                games.entry(id6).or_insert_with(|| game.clone());
+            }
+
+            // Also insert with 4-char ID for compatibility
+            if id.len() >= 4 {
+                let id4 = id[..4].to_string();
+                games.entry(id4).or_insert(game);
+            }
+        }
+
+        log::info!("Loaded {} unique game IDs from GameTDB", games.len());
+        Ok(Self { games })
+    }
+
+    pub fn load_from_base_dir(base_dir: &Path) -> Option<&'static Self> {
+        GAMETDB_INSTANCE
+            .get_or_init(|| {
+                let wiitdb_path = base_dir.join("apps/usbloader_gx/wiitdb.xml");
+                if wiitdb_path.exists() {
+                    match Self::load(&wiitdb_path) {
+                        Ok(db) => {
+                            log::info!("GameTDB loaded successfully from {:?}", wiitdb_path);
+                            Some(db)
+                        }
+                        Err(e) => {
+                            log::error!("Failed to load GameTDB: {}", e);
+                            None
+                        }
+                    }
+                } else {
+                    log::debug!("GameTDB not found at {:?}", wiitdb_path);
+                    None
+                }
+            })
+            .as_ref()
+    }
+
+    pub fn get_game(&self, id: &str) -> Option<&GameEntry> {
+        // Try full ID first
+        self.games.get(id).or_else(|| {
+            // Try first 6 characters
+            if id.len() >= 6 {
+                self.games.get(&id[..6])
+            } else if id.len() >= 4 {
+                // Try first 4 characters
+                self.games.get(&id[..4])
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn get_title(&self, id: &str, locale: Option<&str>) -> Option<String> {
+        let game = self.get_game(id)?;
+
+        // Try specified locale
+        if let Some(locale_str) = locale
+            && let Some(locale_info) = game.locales.iter().find(|l| l.lang == locale_str)
+            && !locale_info.title.is_empty()
+        {
+            return Some(locale_info.title.clone());
+        }
+
+        // Try English as fallback
+        if let Some(locale_info) = game.locales.iter().find(|l| l.lang == "EN")
+            && !locale_info.title.is_empty()
+        {
+            return Some(locale_info.title.clone());
+        }
+
+        // Try any available locale
+        if let Some(locale_info) = game.locales.first()
+            && !locale_info.title.is_empty()
+        {
+            return Some(locale_info.title.clone());
+        }
+
+        // Fallback to game name
+        if !game.name.is_empty() {
+            Some(game.name.clone())
+        } else {
+            None
+        }
+    }
+
+    #[allow(dead_code)] // Will be used for game info display
+    pub fn get_synopsis(&self, id: &str, locale: Option<&str>) -> Option<String> {
+        let game = self.get_game(id)?;
+
+        // Try specified locale
+        if let Some(locale_str) = locale
+            && let Some(locale_info) = game.locales.iter().find(|l| l.lang == locale_str)
+            && let Some(ref synopsis) = locale_info.synopsis
+            && !synopsis.is_empty()
+        {
+            return Some(synopsis.clone());
+        }
+
+        // Try English as fallback
+        if let Some(locale_info) = game.locales.iter().find(|l| l.lang == "EN")
+            && let Some(ref synopsis) = locale_info.synopsis
+            && !synopsis.is_empty()
+        {
+            return Some(synopsis.clone());
+        }
+
+        // Try any available locale
+        for locale_info in &game.locales {
+            if let Some(ref synopsis) = locale_info.synopsis
+                && !synopsis.is_empty()
+            {
+                return Some(synopsis.clone());
+            }
+        }
+
+        None
+    }
+
+    #[allow(dead_code)] // Will be used for game info display
+    pub fn get_developer(&self, id: &str) -> Option<String> {
+        self.get_game(id)?.developer.clone()
+    }
+
+    #[allow(dead_code)] // Will be used for game info display
+    pub fn get_publisher(&self, id: &str) -> Option<String> {
+        self.get_game(id)?.publisher.clone()
+    }
+
+    #[allow(dead_code)] // Will be used for game info display
+    pub fn get_genre(&self, id: &str) -> Option<String> {
+        self.get_game(id)?.genre.clone()
+    }
+
+    #[allow(dead_code)] // Will be used for game info display
+    pub fn get_rating(&self, id: &str) -> Option<(String, String)> {
+        let game = self.get_game(id)?;
+        if let Some(ref rating) = game.rating
+            && let (Some(rating_type), Some(value)) = (&rating.rating_type, &rating.value)
+            && !rating_type.is_empty()
+            && !value.is_empty()
+        {
+            return Some((rating_type.clone(), value.clone()));
+        }
+        None
+    }
+
+    #[allow(dead_code)] // Will be used for game info display
+    pub fn get_players(&self, id: &str) -> Option<u8> {
+        self.get_game(id)?.input.as_ref()?.players
+    }
+
+    #[allow(dead_code)] // Useful for debugging and stats
+    pub fn game_count(&self) -> usize {
+        // Count unique game entries (not including duplicates for 4/6 char IDs)
+        self.games
+            .values()
+            .filter(|g| g.id.len() == 6) // Count only full IDs
+            .count()
+    }
+
+    #[allow(dead_code)] // May be useful for testing or future hot-reload features
+    pub fn clear_cache() {
+        // This would only be used in tests or when reloading
+        // Since we use OnceLock, we can't actually clear it in production
+        // But this is here for API completeness
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn get_test_wiitdb_path() -> PathBuf {
+        PathBuf::from("wiitdb.xml")
+    }
+
+    #[test]
+    fn test_load_wiitdb() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found in project root");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+        assert!(
+            db.game_count() > 10000,
+            "Expected at least 10000 games, got {}",
+            db.game_count()
+        );
+    }
+
+    #[test]
+    fn test_get_game_by_id() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Test with Super Mario Galaxy (RMGE01)
+        let game = db.get_game("RMGE01");
+        assert!(game.is_some(), "Should find Super Mario Galaxy");
+
+        let game = game.unwrap();
+        assert_eq!(game.id, "RMGE01");
+        assert!(!game.locales.is_empty());
+    }
+
+    #[test]
+    fn test_get_game_with_partial_id() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Test with 4-char ID
+        let game = db.get_game("RMGE");
+        assert!(game.is_some(), "Should find game with 4-char ID");
+
+        // Test with 6-char ID
+        let game = db.get_game("RMGE01");
+        assert!(game.is_some(), "Should find game with 6-char ID");
+    }
+
+    #[test]
+    fn test_get_title() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Test getting English title
+        let title = db.get_title("RMGE01", Some("EN"));
+        assert!(
+            title.is_some(),
+            "Should find English title for Super Mario Galaxy"
+        );
+        assert!(
+            title.unwrap().contains("Mario"),
+            "Title should contain 'Mario'"
+        );
+
+        // Test fallback to any available locale
+        let title = db.get_title("RMGE01", Some("ZZ")); // Non-existent locale
+        assert!(title.is_some(), "Should fallback to available title");
+    }
+
+    #[test]
+    fn test_get_synopsis() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Test getting synopsis for a known game
+        let synopsis = db.get_synopsis("RMGE01", Some("EN"));
+        assert!(
+            synopsis.is_some(),
+            "Should find synopsis for Super Mario Galaxy"
+        );
+    }
+
+    #[test]
+    fn test_game_metadata() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Test various metadata fields
+        let developer = db.get_developer("RMGE01");
+        assert!(developer.is_some(), "Should have developer");
+
+        let publisher = db.get_publisher("RMGE01");
+        assert!(publisher.is_some(), "Should have publisher");
+
+        let game = db
+            .get_game("RMGE01")
+            .expect("Should find Super Mario Galaxy");
+        assert!(game.region.is_some(), "Should have region");
+        assert!(game.languages.is_some(), "Should have languages");
+    }
+
+    #[test]
+    fn test_multiple_locales() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Find a game with multiple locales (many games have multiple)
+        // Using RMGE01 which should have multiple language support
+        let game = db.get_game("RMGE01").expect("Should find game");
+        assert!(!game.locales.is_empty(), "Should have at least one locale");
+
+        // Check that EN locale exists for this game
+        let has_en = game.locales.iter().any(|l| l.lang == "EN");
+        assert!(has_en, "Should have English locale");
+    }
+
+    #[test]
+    fn test_rating_info() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Test rating for a known game
+        let rating = db.get_rating("RMGE01");
+        if let Some((rating_type, value)) = rating {
+            assert!(!rating_type.is_empty(), "Rating type should not be empty");
+            assert!(!value.is_empty(), "Rating value should not be empty");
+        }
+    }
+
+    #[test]
+    fn test_nonexistent_game() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        let game = db.get_game("ZZZZZZ");
+        assert!(game.is_none(), "Should not find non-existent game");
+
+        let title = db.get_title("ZZZZZZ", Some("EN"));
+        assert!(
+            title.is_none(),
+            "Should not find title for non-existent game"
+        );
+    }
+
+    #[test]
+    fn test_additional_metadata() {
+        let path = get_test_wiitdb_path();
+        if !path.exists() {
+            eprintln!("Skipping test: wiitdb.xml not found");
+            return;
+        }
+
+        let db = GameTDB::load(&path).expect("Failed to load GameTDB");
+
+        // Test getting genre
+        let genre = db.get_genre("RMGE01");
+        // Genre might not be present for all games
+        if genre.is_some() {
+            assert!(
+                !genre.unwrap().is_empty(),
+                "Genre should not be empty if present"
+            );
+        }
+
+        // Test getting player count
+        let players = db.get_players("RMGE01");
+        // Player count might not be present for all games
+        if players.is_some() {
+            assert!(players.unwrap() > 0, "Player count should be positive");
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,2 +1,3 @@
+pub mod gametdb;
 pub mod redump;
 pub mod split;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod gametdb;
 pub mod redump;
+pub mod regions;
 pub mod split;

--- a/src/util/regions.rs
+++ b/src/util/regions.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025 Manuel Quarneti <mq1@ik.me>
+// SPDX-License-Identifier: GPL-2.0-only
+
+use phf::phf_map;
+
+/// A static map to convert the region character from a game's ID to a language code
+/// used by the GameTDB API for fetching cover art.
+pub static REGION_TO_LANG: phf::Map<char, &'static str> = phf_map! {
+    'A' => "EN", // System Wii Channels (i.e. Mii Channel)
+    'B' => "EN", // Ufouria: The Saga (NA)
+    'D' => "DE", // Germany
+    'E' => "US", // USA
+    'F' => "FR", // France
+    'H' => "NL", // Netherlands
+    'I' => "IT", // Italy
+    'J' => "JA", // Japan
+    'K' => "KO", // Korea
+    'L' => "EN", // Japanese import to Europe, Australia and other PAL regions
+    'M' => "EN", // American import to Europe, Australia and other PAL regions
+    'N' => "US", // Japanese import to USA and other NTSC regions
+    'P' => "EN", // Europe and other PAL regions such as Australia
+    'Q' => "KO", // Japanese Virtual Console import to Korea
+    'R' => "RU", // Russia
+    'S' => "ES", // Spain
+    'T' => "KO", // American Virtual Console import to Korea
+    'U' => "EN", // Australia / Europe alternate languages
+    'V' => "EN", // Scandinavia
+    'W' => "ZH", // Republic of China (Taiwan) / Hong Kong / Macau
+    'X' => "EN", // Europe alternate languages / US special releases
+    'Y' => "EN", // Europe alternate languages / US special releases
+    'Z' => "EN", // Europe alternate languages / US special releases
+};


### PR DESCRIPTION
There's still things clean up in here, and I wanted to get feedback on the larger changes, so opening as a draft for now. Sorry it's huge! I'd recommend pulling it locally and clicking around.

This PR:
- Brings over the "jobs" system that I wrote for [objdiff](https://github.com/encounter/objdiff/blob/main/objdiff-core/src/jobs/mod.rs), which lets us handle background jobs in a more unified way. The old approach using bare threads and `BackgroundMessage` was getting very unwieldy.
  - The jobs system handles progress, results/errors, cancellation, single-job-instance limiting, panic handling, and more in a unified way.
- Ports convert, verify and download covers operations to the new job system
- Downloads cover art into USB Loader GX directories (`app/usbloader_gx/images`)
- Adds `wiitdb.xml` download and loading (`app/usbloader_gx/wiitdb.xml`)
- Uses `wiitdb.xml` titles where possible (we could get rid of the hardcoded `title.rs` if desired)
- Improves error toasts (10s duration, error causes printed clearly)

Still to-do:
- Fetch and cache cover art automatically when loading games list
- Display wiitdb.xml info in game info window
- Test directory/cover layout with actual USB Loader GX

Do let me know if you have any suggestions/comments on the job system architecture.