### PR TITLE
doc: add notes for users on arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@
         <br><br>
         ⚡️ If you have a recent CPU (see <a href="https://en.wikipedia.org/wiki/X86-64#Microarchitecture_levels">here</a>), you can get the slightly faster <kbd>TinyWiiBackupManager-vX.X.X-windows-x86_64-v3.zip</kbd>
         <br><br>
+        🔋 If you have a ARM-based PC (see <a href="https://en.wikipedia.org/wiki/List_of_Qualcomm_Snapdragon_systems_on_chips#Snapdragon_X_series">here</a>), you can get the faster, efficient and fully native <kbd>TinyWiiBackupManager-vX.X.X-windows-arm64.AppImage</kbd>
+        <br><br>
         🍨 A scoop package is also available:
         <br>
         <code>scoop bucket add TinyWiiBackupManager https://github.com/mq1/TinyWiiBackupManager</code>


### PR DESCRIPTION
I added notes for Linux users on PCs based on the ARM64 architecture (eg. Snapdragon X Elite)