### PR TITLE
change minimum arm64 macOS version from Big Sur (11) to Tahoe (26)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             arch: arm64
-            min_sys_ver: "11"
+            min_sys_ver: "26"
           - target: x86_64-apple-darwin
             arch: x86_64
             min_sys_ver: "10.12"


### PR DESCRIPTION
I want to change minimum required macOS version from Big Sur (11) to Tahoe (26) on the Apple Silicon (ARM64) target, by the following reason

Most Apple Silicon Mac users are now on macOS Tahoe 26, and remaining Apple Silicon Mac users still on macOS Sequoia 15 or earlier are upgrading to macOS Tahoe 26, this is why Apple Silicon Macs still on macOS Sequoia 15 and earlier are becoming more rare to see as most Apple Silicon Mac users are upgrading to Tahoe (mainly for security reasons, as security updates for Sequoia are mainly targeted to those Intel Macs that cannot upgrade to Tahoe)

With this change, support for macOS Sequoia 15 and earlier becomes only for Intel Macs