### PR TITLE
add warning for attempts to execute win7 version on xp with onecoreapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@
         <br><br>
         ⚠️ This package is untested and may not work
         <br><br>
+        ⛔ Please do not attempt to run this on Windows XP with OneCoreAPI, as apart from being untested on Windows 7/8/8.1, if executed on XP with OneCoreAPI the program will not work, or being extremely unstable if it works
+        <br><br>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
I added a warning for those that are attempting to run Windows 7 version of TWBM on Windows XP with OneCoreAPI, as apart from the Windows 7 version being untested, attempting to run it on XP with OneCoreAPI results in the app crashing and not working, or being extremely unstable if it works and not crashes