### PR TITLE
Add Nix flake packaging and usage docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ out/
 VC-LTL-Binary.zip
 VC-LTL-Binary/
 
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -106,6 +106,34 @@
 
 <br>
 
+## :snowflake: Nix / NixOS (flake)
+
+You can build and run TinyWiiBackupManager directly with Nix flakes.
+
+From a local checkout:
+
+```bash
+nix build path:.#default
+nix run path:.#default
+```
+
+Install to your user profile:
+
+```bash
+nix profile install github:mq1/TinyWiiBackupManager
+```
+
+Open the development shell:
+
+```bash
+nix develop path:.#default
+```
+
+> [!NOTE]
+> Make sure flakes are enabled in your Nix configuration (`experimental-features = nix-command flakes`).
+
+<br>
+
 ## :page_facing_up: Additional Info
 
 For useful tips, check out the [Wiki](https://github.com/mq1/TinyWiiBackupManager/wiki)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,130 @@
+{
+  description = "TinyWiiBackupManager flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+      mkPkgs = system: import nixpkgs { inherit system; };
+      runtimeLibsFor =
+        pkgs: with pkgs; [
+          libGL
+          libxcb
+          libxkbcommon
+          libx11
+          libxcursor
+          libxext
+          libxi
+          libxinerama
+          libxrandr
+          vulkan-loader
+          wayland
+        ];
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = mkPkgs system;
+          lib = pkgs.lib;
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./assets
+              ./build.rs
+              ./Cargo.lock
+              ./Cargo.toml
+              ./package
+              ./src
+            ];
+          };
+          runtimeLibs = runtimeLibsFor pkgs;
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "TinyWiiBackupManager";
+            version = "5.1.23";
+
+            inherit src;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
+
+            nativeBuildInputs = with pkgs; [
+              makeWrapper
+              pkg-config
+            ];
+
+            buildInputs =
+              runtimeLibs
+              ++ (with pkgs; [
+                openssl
+              ]);
+
+            doCheck = false;
+
+            postInstall = ''
+              install -Dm644 package/linux/usr/share/applications/it.mq1.TinyWiiBackupManager.desktop \
+                $out/share/applications/it.mq1.TinyWiiBackupManager.desktop
+              install -Dm644 package/linux/usr/share/metainfo/it.mq1.TinyWiiBackupManager.metainfo.xml \
+                $out/share/metainfo/it.mq1.TinyWiiBackupManager.metainfo.xml
+
+              mkdir -p $out/share/icons
+              cp -r package/linux/usr/share/icons/hicolor $out/share/icons/
+
+              wrapProgram $out/bin/TinyWiiBackupManager \
+                --prefix PATH : ${lib.makeBinPath [ pkgs.xdg-utils ]} \
+                --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath runtimeLibs}
+            '';
+
+            meta = with lib; {
+              description = "A tiny game backup and homebrew app manager for the Wii";
+              homepage = "https://github.com/mq1/TinyWiiBackupManager";
+              license = licenses.gpl3Only;
+              mainProgram = "TinyWiiBackupManager";
+              platforms = platforms.linux;
+            };
+          };
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/TinyWiiBackupManager";
+        };
+      });
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = mkPkgs system;
+          runtimeLibs = runtimeLibsFor pkgs;
+        in
+        {
+          default = pkgs.mkShell {
+            packages =
+              runtimeLibs
+              ++ (with pkgs; [
+                cargo
+                clippy
+                openssl
+                pkg-config
+                rustc
+                rustfmt
+              ]);
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary
- add `flake.nix` and `flake.lock` so the project can be built and run on Nix/NixOS using flakes
- package desktop metadata/icons and include a `devShell` with Rust and required Linux runtime/build libraries
- document Nix flake usage in the README and ignore Nix `result` symlinks in `.gitignore`

## Validation
- `nix flake show path:.`
- `nix build path:.#default`
- `nix run path:.#default`