### PR TITLE
Game Info Modal Tweaks

### DIFF
--- a/ui/components/game-info-modal.slint
+++ b/ui/components/game-info-modal.slint
@@ -60,6 +60,7 @@ export component GameInfoModal inherits Modal {
                 VerticalLayout {
                     spacing: 5px;
                     alignment: center;
+                    y: parent.height - self.height - 10px;
 
                     HorizontalLayout {
                         spacing: 5px;
@@ -121,41 +122,17 @@ export component GameInfoModal inherits Modal {
                         spacing: 5px;
 
                         IconDisplay {
-                            icon: IconSet.Pointer;
+                            icon: IconSet.Gamepad;
                             stroke: MyPalette.foreground;
                             size: 14px;
                         }
 
-                        Text {
-                            text: "Is Wii: \{(UiState.current-disc-info.is-wii ? "yes" : "no")}";
-                        }
-                    }
-
-                    HorizontalLayout {
-                        spacing: 5px;
-
-                        IconDisplay {
-                            icon: IconSet.Box;
-                            stroke: MyPalette.foreground;
-                            size: 14px;
+                        if UiState.current-disc-info.is-gc : Text {
+                            text: "System: GameCube";
                         }
 
-                        Text {
-                            text: "Is GameCube: \{(UiState.current-disc-info.is-gc ? "yes" : "no")}";
-                        }
-                    }
-
-                    HorizontalLayout {
-                        spacing: 5px;
-
-                        IconDisplay {
-                            icon: IconSet.Hash;
-                            stroke: MyPalette.foreground;
-                            size: 14px;
-                        }
-
-                        Text {
-                            text: "Disc number: \{UiState.current-disc-info.disc-number}";
+                        if UiState.current-disc-info.is-wii : Text {
+                            text: "System: Wii";
                         }
                     }
 


### PR DESCRIPTION
This makes two changes that I suggested in #631 to the game info modal:

- Removed the disc number text since it was useless due to TWBM only showing the first disc
- Condensed the "Is Wii/Is GameCube" text to a single line that just mentions what console the game was for
- Shifted the text 10px up so it looks more centered with the cover art

Here's a picture showing the changes:

<img width="748" height="495" alt="image" src="https://github.com/user-attachments/assets/b4bcc9f7-ce83-4f8a-8781-0bccc54576ee" />